### PR TITLE
adding json convertible type and necessary primitive conversions

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,5 +3,6 @@ import PackageDescription
 let package = Package(
     name: "Vapor",
     dependencies: [
+        .Package(url: "https://github.com/gfx/Swift-PureJsonSerializer.git", majorVersion: 1)
     ]
 )

--- a/README.md
+++ b/README.md
@@ -80,6 +80,43 @@ Route.get("version") { request in
 
 This responds to all requests to `http://example.com/version` with the JSON dictionary `{"version": "1.0"}` and `Content-Type: application/json`.
 
+#### Complex Responses
+
+Vapor will do its best to infer a Json response from the returned type, but for some more complex examples, particularly on Linux, there are known inference issues.  To circumvent this, you can use the included `Json` type and wrap your response, for example:
+
+```swift
+Route.get("solar-system") { request in
+	let json = [
+			"planets" : [
+				"mars",
+				"venus",
+				"jupiter",
+				"earth"
+			]
+	]
+	return Json(json)
+}
+```
+
+#### Requests
+
+To access Json from parameters sent up with a request, use `request.json`
+
+```swift
+Route.post("messages") { request in
+	guard
+		   let json = request.json,
+			 let userId = json["userId"]?.stringValue,
+			 let messageBody = json["message"]?.stringValue
+			 else { throw error }
+
+	let message = Message(userId: userId, body: messageBody)
+	message.save()
+
+	return Response(status: .OK, text: "Message Created")
+}
+```
+
 ### Views
 
 You can also respond with HTML pages.

--- a/Sources/Vapor+Json.swift
+++ b/Sources/Vapor+Json.swift
@@ -16,8 +16,9 @@ public typealias JSON = Json
 
 extension Json : ResponseConvertible {
     public func response() -> Response {
-        let js = serialize(.PrettyPrint)
-        return Response(status: .OK, text: js)
+        let js = serialize()
+        let data = Array(js.utf8)
+        return Response(status: .OK, data: data, contentType: .Json)
     }
 }
 

--- a/Sources/Vapor+Json.swift
+++ b/Sources/Vapor+Json.swift
@@ -1,0 +1,250 @@
+//
+//  Vapor+Json.swift
+//  Vapor
+//
+//  Created by Logan Wright on 2/19/16.
+//  Copyright © 2016 Tanner Nelson. All rights reserved.
+//
+
+import Foundation
+@_exported import PureJsonSerializer
+
+/// To allow users to opt into preferred case style
+public typealias JSON = Json
+
+// MARK: Response
+
+extension Json : ResponseConvertible {
+    public func response() -> Response {
+        let js = serialize(.PrettyPrint)
+        return Response(status: .OK, text: js)
+    }
+}
+
+// MARK: Request Json
+
+extension Request {
+
+    /**
+     If the body can be serialized as Json, the value will be returned here
+     */
+    public var json: Json? {
+        return try? Json.deserialize(body)
+    }
+}
+
+// MARK: Json Convertible 
+
+public enum JsonError: ErrorType {
+    
+    /**
+     *  When converting to a value from Json, if there is a type conflict, this will throw an error
+     *
+     *  @param Json   the json that was unable to map
+     *  @param String a string description of the type that was attempting to map
+     */
+    case UnableToConvert(json: Json, toType: String)
+}
+
+/**
+ *  An umbrella protocol used to define behavior to and from Json
+ */
+public protocol JsonConvertible {
+    
+    /**
+     This function will be used to create an instance of the type from Json
+     
+     - parameter json: the json to use in initialization
+     
+     - throws: a potential error.  ie: invalid json type
+     
+     - returns: an initialized object
+     */
+    static func newInstance(json: Json) throws -> Self
+    
+    /**
+     Used to convert the object back to its Json representation
+     
+     - throws: a potential conversion error
+     
+     - returns: the object as a Json representation
+     */
+    func jsonRepresentation() throws -> Json
+}
+
+// MARK: Json Convertible Initializers
+
+extension Json {
+    
+    /**
+     Create Json from any convertible type
+     
+     - parameter any: the convertible type
+     
+     - throws: a potential conversion error
+     
+     - returns: initialized Json
+     */
+    public init<T: JsonConvertible>(_ any: T) throws {
+        self = try any.jsonRepresentation()
+    }
+    
+    public init<T: JsonConvertible>(_ any: [T]) throws {
+        let mapped = try any.map(Json.init)
+        self.init(mapped)
+    }
+    
+    public init<T: JsonConvertible>(_ any: [[T]]) throws {
+        let mapped = try any.map(Json.init)
+        self.init(mapped)
+    }
+    
+    public init<T: JsonConvertible>(_ any: Set<T>) throws {
+        let mapped = try any.map(Json.init)
+        self.init(mapped)
+    }
+    
+    public init<T: JsonConvertible>(_ any: [String : T]) throws {
+        var mapped: [String : Json] = [:]
+        try any.forEach { key, val in
+            mapped[key] = try Json(val)
+        }
+        self.init(mapped)
+    }
+    
+    public init<T: JsonConvertible>(_ any: [String : [T]]) throws {
+        var mapped: [String : Json] = [:]
+        try any.forEach { key, val in
+            mapped[key] = try Json(val)
+        }
+        self.init(mapped)
+    }
+    
+    public init<T: JsonConvertible>(_ any: [String : [String : T]]) throws {
+        var mapped: [String : Json] = [:]
+        try any.forEach { key, val in
+            mapped[key] = try Json(val)
+        }
+        self.init(mapped)
+    }
+}
+
+extension Json : JsonConvertible {
+    public static func newInstance(json: Json) -> Json {
+        return json
+    }
+    
+    public func jsonRepresentation() -> Json {
+        return self
+    }
+}
+
+// MARK: String
+
+extension String : JsonConvertible {
+    public func jsonRepresentation() throws -> Json {
+        return Json(self)
+    }
+    
+    public static func newInstance(json: Json) throws -> String {
+        guard let string = json.stringValue else {
+            throw JsonError.UnableToConvert(json: json, toType: "\(self.dynamicType)")
+        }
+        return string
+    }
+}
+
+// MARK: Boolean
+
+extension Bool : JsonConvertible {
+    public func jsonRepresentation() throws -> Json {
+        return Json(self)
+    }
+    
+    public static func newInstance(json: Json) throws -> Bool {
+        guard let bool = json.boolValue else {
+            throw JsonError.UnableToConvert(json: json, toType: "\(self.dynamicType)")
+        }
+        return bool
+    }
+}
+
+
+// MARK: UnsignedIntegerType
+
+extension UInt : JsonConvertible {}
+extension UInt8 : JsonConvertible {}
+extension UInt16 : JsonConvertible {}
+extension UInt32 : JsonConvertible {}
+extension UInt64 : JsonConvertible {}
+
+extension UnsignedIntegerType {
+    public func jsonRepresentation() throws -> Json {
+        let double = Double(UIntMax(self.toUIntMax()))
+        return .from(double)
+    }
+    
+    public static func newInstance(json: Json) throws -> Self {
+        guard let int = json.uintValue else {
+            throw JsonError.UnableToConvert(json: json, toType: "\(self.dynamicType)")
+        }
+        
+        return self.init(int.toUIntMax())
+    }
+}
+
+// MARK: SignedIntegerType
+
+extension Int : JsonConvertible {}
+extension Int8 : JsonConvertible {}
+extension Int16 : JsonConvertible {}
+extension Int32 : JsonConvertible {}
+extension Int64 : JsonConvertible {}
+
+extension SignedIntegerType {
+    public func jsonRepresentation() throws -> Json {
+        let double = Double(IntMax(self.toIntMax()))
+        return .from(double)
+    }
+    
+    public static func newInstance(json: Json) throws -> Self {
+        guard let int = json.intValue else {
+            throw JsonError.UnableToConvert(json: json, toType: "\(self.dynamicType)")
+        }
+        
+        return self.init(int.toIntMax())
+    }
+}
+
+
+// MARK: FloatingPointType
+
+extension Float : JsonConvertibleFloatingPointType {
+    public var doubleValue: Double {
+        return Double(self)
+    }
+}
+
+extension Double : JsonConvertibleFloatingPointType {
+    public var doubleValue: Double {
+        return Double(self)
+    }
+}
+
+public protocol JsonConvertibleFloatingPointType : JsonConvertible {
+    var doubleValue: Double { get }
+    init(_ other: Double)
+}
+
+extension JsonConvertibleFloatingPointType {
+    public func jsonRepresentation() throws -> Json {
+        return .from(doubleValue)
+    }
+    
+    public static func newInstance(json: Json) throws -> Self {
+        guard let double = json.doubleValue else {
+            throw JsonError.UnableToConvert(json: json, toType: "\(self.dynamicType)")
+        }
+        return self.init(double)
+    }
+}

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -7,8 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3492B2ED1C7819D800D8E588 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EC1C7819D800D8E588 /* main.swift */; };
 		3492B2EF1C787DD600D8E588 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EE1C787DD600D8E588 /* RouteTests.swift */; };
+		802030011C77C956009B8655 /* Vapor+Json.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802030001C77C956009B8655 /* Vapor+Json.swift */; };
 		C304C8A71C62D65200058C92 /* ServerDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304C8A61C62D65200058C92 /* ServerDriver.swift */; };
 		C304C8A81C62D65200058C92 /* ServerDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304C8A61C62D65200058C92 /* ServerDriver.swift */; };
 		C304C8AA1C62FCA300058C92 /* RequestFormExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304C8A91C62FCA300058C92 /* RequestFormExtension.swift */; };

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -76,8 +76,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		3492B2EC1C7819D800D8E588 /* main.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		3492B2EE1C787DD600D8E588 /* RouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
+		802030001C77C956009B8655 /* Vapor+Json.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Vapor+Json.swift"; sourceTree = "<group>"; };
 		C304C8A01C62C3F400058C92 /* .travis.yml */ = {isa = PBXFileReference; lastKnownFileType = text; path = .travis.yml; sourceTree = "<group>"; };
 		C304C8A61C62D65200058C92 /* ServerDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ServerDriver.swift; sourceTree = "<group>"; };
 		C304C8A91C62FCA300058C92 /* RequestFormExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RequestFormExtension.swift; sourceTree = "<group>"; };
@@ -135,6 +135,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		80202FFF1C77C94C009B8655 /* Json */ = {
+			isa = PBXGroup;
+			children = (
+				802030001C77C956009B8655 /* Vapor+Json.swift */,
+			);
+			name = Json;
+			sourceTree = "<group>";
+		};
 		C304C8AC1C63047100058C92 /* Socket */ = {
 			isa = PBXGroup;
 			children = (
@@ -241,7 +249,7 @@
 		C352E6D11C62BC6A00E26467 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				3492B2EC1C7819D800D8E588 /* main.swift */,
+				80202FFF1C77C94C009B8655 /* Json */,
 				C377F2ED1C696C9B00DABD21 /* View */,
 				C304C8B21C63054400058C92 /* Routing */,
 				C304C8B01C63053500058C92 /* Request */,
@@ -418,7 +426,7 @@
 				C352E6FB1C62BC6A00E26467 /* NodeRouter.swift in Sources */,
 				C352E6F51C62BC6A00E26467 /* Response.swift in Sources */,
 				C352E6E91C62BC6A00E26467 /* JSONSerializer.swift in Sources */,
-				3492B2ED1C7819D800D8E588 /* main.swift in Sources */,
+				802030011C77C956009B8655 /* Vapor+Json.swift in Sources */,
 				C352E6EB1C62BC6A00E26467 /* LinuxFixes.swift in Sources */,
 				C352E6E71C62BC6A00E26467 /* Controller.swift in Sources */,
 				C304C8A71C62D65200058C92 /* ServerDriver.swift in Sources */,
@@ -557,6 +565,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/.build/debug";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -567,6 +576,7 @@
 				CLANG_ENABLE_MODULES = YES;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/.build/release";
 			};
 			name = Release;
 		};
@@ -578,6 +588,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tannernelson.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/.build/debug";
 			};
 			name = Debug;
 		};
@@ -589,6 +600,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tannernelson.Tests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = "$(SRCROOT)/.build/release";
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- [x] Add json convertible type
- [x] Update readme
- [x] Discuss implications of inclusion and possibly create separate package for json convertible inclusion as opt-in, also allows users to specify a Json library if desired

> Result of discussion.  There's no harm on this inclusion since it's completely disconnected from core.  If a user prefers something else, there's nothing preventing them. Inclusion makes it easier for users unsure of their preference

Helps w/ #28 and #23 