### PR TITLE
WIP: Service Provider Support

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -1,10 +1,5 @@
-public func app() -> Application {
-	return Application.getInstance()
-}
-
 public class Application {
 	public static let VERSION = "0.1.9"
-	private static var instance: Application?
 
 	private var serviceProviders = Array<ServiceProvider>()
 	public private(set) var booted = false
@@ -16,21 +11,6 @@ public class Application {
 
 	public init(serverDriver: ServerDriver) {
 		self.server = Server(driver: serverDriver)
-		self.dynamicType.setInstance(self)
-	}
-
-	public static func getInstance() -> Application {
-		if let instance = self.instance {
-			return instance
-		}
-
-		let instance = Application()
-		self.setInstance(instance)
-		return instance
-	}
-
-	public static func setInstance(instance: Application) {
-		self.instance = instance
 	}
 
 	public func register(providers: [ServiceProvider.Type]) {

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -1,0 +1,43 @@
+public func app() -> Application {
+	return Application.getInstance()
+}
+
+public class Application {
+	public static let VERSION = "0.1.9"
+	private static var instance: Application?
+
+	public private(set) var booted = false
+	public let server: Server
+
+	public convenience init() {
+		self.init(serverDriver: SocketServer())
+	}
+
+	public init(serverDriver: ServerDriver) {
+		self.server = Server(driver: serverDriver)
+		self.dynamicType.setInstance(self)
+	}
+
+	public static func getInstance() -> Application {
+		if let instance = self.instance {
+			return instance
+		}
+
+		let instance = Application()
+		self.setInstance(instance)
+		return instance
+	}
+
+	public static func setInstance(instance: Application) {
+		self.instance = instance
+	}
+
+	public func boot() {
+		if self.booted {
+			return
+		}
+
+		self.booted = true
+	}
+
+}

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -6,6 +6,7 @@ public class Application {
 	public static let VERSION = "0.1.9"
 	private static var instance: Application?
 
+	private var serviceProviders = Array<ServiceProvider>()
 	public private(set) var booted = false
 	public let server: Server
 
@@ -32,12 +33,51 @@ public class Application {
 		self.instance = instance
 	}
 
+	public func register(providers: [ServiceProvider.Type]) {
+		for provider in providers {
+			self.register(provider)
+		}
+	}
+
+	public func register<T: ServiceProvider>(provider: T.Type) -> T {
+		if let registered = self.getProvider(provider) {
+			return registered
+		}
+
+		let provider = provider.init(application: self)
+		provider.register()
+
+		if self.booted {
+			self.bootProvider(provider)
+		}
+
+		return provider
+	}
+
+	public func getProvider<T: ServiceProvider>(provider: T.Type) -> T? {
+		for value in self.serviceProviders {
+			if value.dynamicType == provider {
+				return value as? T
+			}
+		}
+
+		return nil
+	}
+
 	public func boot() {
 		if self.booted {
 			return
 		}
 
+		for provider in self.serviceProviders {
+			self.bootProvider(provider)
+		}
+
 		self.booted = true
+	}
+
+	public func bootProvider(provider: ServiceProvider) {
+		provider.boot()
 	}
 
 }

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -1,7 +1,7 @@
 public class Application {
 	public static let VERSION = "0.1.9"
 
-	private var serviceProviders = Array<ServiceProvider>()
+	private var providers = Array<Provider>()
 	public private(set) var booted = false
 	public let server: Server
 
@@ -13,13 +13,13 @@ public class Application {
 		self.server = Server(driver: serverDriver)
 	}
 
-	public func register(providers: [ServiceProvider.Type]) {
+	public func register(providers: [Provider.Type]) {
 		for provider in providers {
 			self.register(provider)
 		}
 	}
 
-	public func register<T: ServiceProvider>(provider: T.Type) -> T {
+	public func register<T: Provider>(provider: T.Type) -> T {
 		if let registered = self.getProvider(provider) {
 			return registered
 		}
@@ -34,8 +34,8 @@ public class Application {
 		return provider
 	}
 
-	public func getProvider<T: ServiceProvider>(provider: T.Type) -> T? {
-		for value in self.serviceProviders {
+	public func getProvider<T: Provider>(provider: T.Type) -> T? {
+		for value in self.providers {
 			if value.dynamicType == provider {
 				return value as? T
 			}
@@ -49,14 +49,14 @@ public class Application {
 			return
 		}
 
-		for provider in self.serviceProviders {
+		for provider in self.providers {
 			self.bootProvider(provider)
 		}
 
 		self.booted = true
 	}
 
-	public func bootProvider(provider: ServiceProvider) {
+	public func bootProvider(provider: Provider) {
 		provider.boot()
 	}
 

--- a/Sources/Provider.swift
+++ b/Sources/Provider.swift
@@ -1,4 +1,4 @@
-public class ServiceProvider {
+public class Provider {
 	public let application: Application
 
 	public required init(application: Application) {

--- a/Sources/Response.swift
+++ b/Sources/Response.swift
@@ -147,7 +147,7 @@ public class Response {
     }
 
     var headers: [String: String] {
-        var headers = ["Server" : "Vapor \(Server.VERSION)"]
+        var headers = ["Server" : "Vapor \(Application.VERSION)"]
 
         if self.cookies.count > 0 {
             var cookieString = ""

--- a/Sources/Server.swift
+++ b/Sources/Server.swift
@@ -6,9 +6,7 @@ import Foundation
 
 
 public class Server {
-    
-    public static let VERSION = "0.1.9"
-    
+
     /**
         The router driver is responsible
         for returning registered `Route` handlers

--- a/Sources/ServiceProvider.swift
+++ b/Sources/ServiceProvider.swift
@@ -1,0 +1,16 @@
+public class ServiceProvider {
+	public let application: Application
+
+	public required init(application: Application) {
+		self.application = application
+	}
+
+	public func register() {
+
+	}
+
+	public func boot() {
+
+	}
+
+}


### PR DESCRIPTION
Working on adding in Service Provider support for more flexibility with third party packages.

I've refactored things a bit to use a global Application class where service providers are registered.  The application class now maintains the server instance, so `main.swift` in apps would need to be updated to look like this:

```swift
let application = Application()
// application.register(SomeServiceProvider.self)
application.boot()
application.server.run(port: 8080)
```

## TODO
- [ ] Gather feedback
- [ ] Test coverage

## Example

Using VaporStencil as an example, instead of having to include `View.renderers[".stencil"] = StencilRenderer()` in `main.swift`, we could create `StencilServiceProvider`:

```swift
import Vapor

public class StencilServiceProvider: ServiceProvider {

	public override func register() {
		View.renderers[".stencil"] = StencilRenderer()
	}

}
```

And in main.swift, it would look like:

```swift
let application = Application()
application.register(StencilServiceProvider.self)
```