### PR TITLE
Protocolize Controller

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ import Vapor
 
 class HeartbeatController: Controller {
 
-	override func index(request: Request) -> AnyObject {
+	func index(request: Request) throws -> ResponseConvertible {
 		return ["lub": "dub"]
 	}
 

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -1,37 +1,45 @@
 /**
- * Organize your routing logic with a subclass of
- * `Controller`. Controlls group related route logic into
- * a single class that, by default, conforms to standard
+ * Organize your routing logic with a conformance of
+ * `Controller`. Controls group related route logic into
+ * a single protocol that, by default, conforms to standard
  * CRUD operations.
  */
-public class Controller {
+public protocol Controller: class {
+    /// Display many instances
+	func index(request: Request) throws -> ResponseConvertible
 
-	///Create a default controller
-	public init() {}
+    /// Create a new instance.
+    func store(request: Request) throws -> ResponseConvertible
 
-    ///Display many instances
+    /// Show an instance.
+    func show(request: Request) throws -> ResponseConvertible
+
+    /// Update an instance.
+    func update(request: Request) throws -> ResponseConvertible
+
+    /// Delete an instance.
+    func destroy(request: Request) throws -> ResponseConvertible
+
+}
+
+extension Controller {
 	public func index(request: Request) throws -> ResponseConvertible {
 		return "index"
 	}
 
-	///Create a new instance.
 	public func store(request: Request) throws -> ResponseConvertible {
 		return "store"
 	}
 
-	///Show an instance.
 	public func show(request: Request) throws -> ResponseConvertible {
 		return "show"
 	}
 
-    ///Update an instance.
 	public func update(request: Request) throws -> ResponseConvertible {
 		return "update"
 	}
 
-	///Delete an instance.
 	public func destroy(request: Request) throws -> ResponseConvertible {
 		return "destroy"
-	}
-    
+	}    
 }


### PR DESCRIPTION
I felt like Controller would be best served as a Protocol with default implementations. This would remove the restriction of subclassing Controller directly.

Unfortunately, I couldn't get the Xcode Project or the unit tests to run, but this does build.

This would be a breaking change for existing implementations of Controller in that they would have to remove their `override` keyword, but I feel like it's not very substantial.