### PR TITLE
Add support for route specific middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,18 @@ class MyMiddleware: Middleware {
 app.middleware.append(MyMiddleware)
 ```
 
+Middleware can also be applied to a specific set of routes by using the `app.middleware(_: handler:)` method.
+
+```swift
+app.get("welcome") { ... }
+
+app.middleware([AuthMiddleware]) {
+   app.get("user") { ... }
+}
+```
+
+In this example the `AuthMiddleware` will be applied to the `user` route but not the `welcome` route.
+
 ## Providers
 
 [Providers](https://github.com/qutheory/vapor/wiki/Provider) and [Drivers](https://github.com/qutheory/vapor/wiki/Driver) allow almost any component of Vapor to be extended or replaced.

--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -53,6 +53,13 @@ public class Application {
 	}
     
     internal var host: String = "*"
+    
+    /**
+        An array of arrays representing middleware to apply
+        to a specific set of routes that are registered inside
+        of the middleware(_: closure:) function
+    */
+    internal var currentMiddlewareTypes = [[Middleware.Type]]()
 
 	/**
 		Initialize the Application.
@@ -72,6 +79,17 @@ public class Application {
         for provider in self.providers {
             provider.boot(self)
         }
+    }
+    
+    /**
+        Applies the middleware to the routes defined 
+        inside the closure. This method can be nested within
+        itself safely.
+    */
+    public func middleware(middleware: [Middleware.Type], closure: () -> ()) {
+        currentMiddlewareTypes.append(middleware)
+        closure()
+        currentMiddlewareTypes.removeLast()
     }
 
 

--- a/Sources/BranchRouter.swift
+++ b/Sources/BranchRouter.swift
@@ -66,9 +66,17 @@ extension Application {
     }
     
     public final func add(method: Request.Method, path: String, closure: Handler) {
-        router.register(hostname: host, method: method, path: path) { request in
+        
+        var handler = { request in
             return try closure(request).response()
         }
+      
+        // The call to app.middleware can nested so we need to flatten it
+        for middleware in currentMiddlewareTypes.flatten() {
+            handler = middleware.handle(handler)
+        }
+        
+        router.register(hostname: host, method: method, path: path, handler: handler)
     }
     
     public final func host(host: String, closure: () -> Void) {


### PR DESCRIPTION
This is a proposal/basic implementation to support route specific middleware. I have not added tests and have only done minimal work to get this working because I wanted to get feedback before pursuing this any further. 

The main points are that that we would add a new struct `RouteDescriptor` which contains information about the route. The `RouteDriver` protocol would then be updated to register and return the `RouteDescriptor` object instead of the `Request.Handler`.

The `Application` has been updated to take a `[Middleware.Type]` array on all of its route registration methods. By defaulting to `[]` on all these methods we don't break any existing code but we do need to update the `BranchRouter` and `Branch` to work directly with the `RouteDescriptor` instead of the handlers.

This allows us to write route definitions like the following:
```swift
app.get("welcome") { _ in
    return "Hello"
}

app.get("user", middlewares: [AuthMiddleware.self]) { _ in
    return [user: user]
}

app.middleware.append(GlobalMiddleware)
```
In the above example we run `GlobalMiddleware` on each request and `AuthMiddleware` on the `/user` request.

Let me know if this is something that you think would be worthwhile and worthy of breaking the `RouteDriver` protocol for and I will clean it up.