### PR TITLE
Events and Subscribers

### DIFF
--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -35,8 +35,10 @@ public class Event<T, U where T: EventType, U: Any> {
             }
             .sort { $0.priority > $1.priority }
         
-        subscribed.forEach { subscriber in
-            subscriber.handle(event.data)
+        for subscriber in subscribed {
+            if !subscriber.handle(event.data) {
+                break
+            }
         }
     }
     
@@ -46,7 +48,7 @@ public class Event<T, U where T: EventType, U: Any> {
     /* Initializer
      
      - parameter type: The EventType used to identify susbcribers that should respond to this event
-     - parameter: data: Any - the data passed to subscribers
+     - parameter: data: Any - the data passed to subscribers to respond to
      */
     public required init(_ type: T, data: U) {
         self.type = type
@@ -56,13 +58,14 @@ public class Event<T, U where T: EventType, U: Any> {
 
 //MARK: Subscriber
 
-public typealias EventHandler = (Any) -> ()
+public typealias Continue = Bool
+public typealias EventHandler = (Any) -> (Continue)
 
 /*
  Subcribers must implement this protocol
  */
 public protocol Subscribable {
-    func handle(data: Any)
+    func handle(data: Any) -> Continue
     var priority: Int { get }
     var type: EventType { get }
 }
@@ -117,7 +120,7 @@ public class Subscriber: Subscribable {
     /*
      This calls the closure
     */
-    public func handle(data: Any) {
-        closure(data)
+    public func handle(data: Any) -> Continue {
+        return closure(data)
     }
 }

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -1,0 +1,52 @@
+//
+//  Event.swift
+//  Vapor
+//
+//  Created by Matthew on 24/02/2016.
+//  Copyright © 2016 Tanner Nelson. All rights reserved.
+//
+
+public class Event<T where T: AnyObject> {
+    
+    public static func fire(event: Event) {
+        let subscribed = Subscriber.registered
+            .filter { subscriber in
+                return subscriber.tag == event.tag
+            }
+            .sort { $0.priority > $1.priority }
+        
+        subscribed.forEach { subscriber in
+            subscriber.handle(event.data)
+        }
+    }
+    
+    let tag: String
+    let data: T
+    
+    public required init(tag: String, data: T) {
+        self.tag = tag
+        self.data = data
+    }
+}
+
+
+public class Subscriber {
+    
+    public typealias EventHandler = (AnyObject) -> ()
+    
+    public static var registered: [Subscriber] = []
+    
+    public let tag: String
+    public let priority: Int
+    public let closure: EventHandler
+    
+    public required init(subscribesTo tag: String, priority: Int, closure: EventHandler) {
+        self.tag = tag
+        self.priority = priority
+        self.closure = closure
+    }
+    
+    public func handle(data: AnyObject) {
+        closure(data)
+    }
+}

--- a/Sources/Event.swift
+++ b/Sources/Event.swift
@@ -6,7 +6,39 @@
 //  Copyright © 2016 Tanner Nelson. All rights reserved.
 //
 
-public class Event<T where T: AnyObject> {
+
+
+/*
+ 
+EXAMPLE
+
+let high = Subscriber(subscribesTo: "event.name", priority: 100) { data in
+    print("High Priority - \(data)")
+}
+
+let low = Subscriber(subscribesTo: "event.name") { data in
+    print("Standard Priority - \(data)")
+}
+
+let other = Subscriber(subscribesTo: "other.name") { data in
+    print("Other subscriber - \(data)")
+}
+
+Subscriber.add([low, high, other])
+
+let event = Event(tag: "event.name", data: "This is the data")
+Event.fire(event)
+
+//Prints first
+"High Priority - This is the data"
+//Prints second
+"Standard Priority - This is the data"
+
+ */
+
+public struct Event<T where T: AnyObject> {
+    
+    //MARK: Static methods
     
     public static func fire(event: Event) {
         let subscribed = Subscriber.registered
@@ -20,27 +52,52 @@ public class Event<T where T: AnyObject> {
         }
     }
     
+    //MARK: Properties
+    
     let tag: String
     let data: T
     
-    public required init(tag: String, data: T) {
+    public init(tag: String, data: T) {
         self.tag = tag
         self.data = data
     }
 }
 
+public protocol Subscribable {
+    func handle(data: AnyObject)
+}
 
-public class Subscriber {
+public typealias EventHandler = (AnyObject) -> ()
+
+public class Subscriber: Equatable, Subscribable {
     
-    public typealias EventHandler = (AnyObject) -> ()
+    //MARK: Static methods
     
-    public static var registered: [Subscriber] = []
+    private static var registered: [Subscriber] = []
+    
+    public static func add(subscriber: Subscriber) {
+        Subscriber.registered.append(subscriber)
+    }
+    
+    public static func add(subscribers: [Subscriber]) {
+        Subscriber.registered += subscribers
+    }
+    
+//    
+//    public static func remove(subscriber: Subscriber) {
+//        guard let index = Subscriber.registered
+//            .indexOf(subscriber) else { return }
+//        
+//        Subscriber.registered.removeAtIndex(index)
+//    }
+    
+    //MARK: Properties
     
     public let tag: String
     public let priority: Int
     public let closure: EventHandler
     
-    public required init(subscribesTo tag: String, priority: Int, closure: EventHandler) {
+    public required init(subscribesTo tag: String, priority: Int = 50, closure: EventHandler) {
         self.tag = tag
         self.priority = priority
         self.closure = closure
@@ -50,3 +107,8 @@ public class Subscriber {
         closure(data)
     }
 }
+
+public func ==(lhs: Subscriber, rhs: Subscriber) -> Bool {
+    return String(lhs) == String(rhs)
+}
+

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		34CC595B1C7BE405007CA680 /* Log.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59571C7BE405007CA680 /* Log.swift */; };
 		34CC59621C7C5A03007CA680 /* LogDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59611C7C5A03007CA680 /* LogDriver.swift */; };
 		34CC59631C7C5A1B007CA680 /* LogDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59611C7C5A03007CA680 /* LogDriver.swift */; };
+		34CC59661C7DC8B9007CA680 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59651C7DC8B9007CA680 /* Event.swift */; };
+		34CC59671C7DCAE3007CA680 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59651C7DC8B9007CA680 /* Event.swift */; };
 		802030011C77C956009B8655 /* Vapor+JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802030001C77C956009B8655 /* Vapor+JSON.swift */; };
 		802030121C78CAC2009B8655 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802030101C78CAC2009B8655 /* Branch.swift */; };
 		802030131C78CAC2009B8655 /* Branch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802030101C78CAC2009B8655 /* Branch.swift */; };
@@ -98,6 +100,7 @@
 		34CC59551C7BE3C9007CA680 /* LogTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogTests.swift; sourceTree = "<group>"; };
 		34CC59571C7BE405007CA680 /* Log.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Log.swift; sourceTree = "<group>"; };
 		34CC59611C7C5A03007CA680 /* LogDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LogDriver.swift; sourceTree = "<group>"; };
+		34CC59651C7DC8B9007CA680 /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		802030001C77C956009B8655 /* Vapor+JSON.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Vapor+JSON.swift"; sourceTree = "<group>"; };
 		802030101C78CAC2009B8655 /* Branch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Branch.swift; sourceTree = "<group>"; };
 		802030161C78CAE1009B8655 /* BranchRouter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BranchRouter.swift; sourceTree = "<group>"; };
@@ -177,6 +180,14 @@
 				34CC59611C7C5A03007CA680 /* LogDriver.swift */,
 			);
 			name = Log;
+			sourceTree = "<group>";
+		};
+		34CC59641C7DC8AA007CA680 /* Event */ = {
+			isa = PBXGroup;
+			children = (
+				34CC59651C7DC8B9007CA680 /* Event.swift */,
+			);
+			name = Event;
 			sourceTree = "<group>";
 		};
 		80202FFF1C77C94C009B8655 /* JSON */ = {
@@ -305,6 +316,7 @@
 		C352E6D11C62BC6A00E26467 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				34CC59641C7DC8AA007CA680 /* Event */,
 				C393E0F31C7CF9A6009F0543 /* main.swift */,
 				288CFC2D1C7AC01A00E4617A /* Application.swift */,
 				C3433FCB1C7CFB39009F0876 /* Routing */,
@@ -482,6 +494,7 @@
 				C352E6F31C62BC6A00E26467 /* Request.swift in Sources */,
 				802053991C7A8C7D009E26E9 /* RequestData+Target.swift in Sources */,
 				C304C8B51C6306B100058C92 /* RouterDriver.swift in Sources */,
+				34CC59661C7DC8B9007CA680 /* Event.swift in Sources */,
 				C3433FD01C7D1134009F0876 /* CryptoSwift.swift in Sources */,
 				C3EDEA871C68459300754727 /* Hash.swift in Sources */,
 				C352E7091C62BC6A00E26467 /* View.swift in Sources */,
@@ -520,6 +533,7 @@
 				C352E6EC1C62BC6A00E26467 /* LinuxFixes.swift in Sources */,
 				C3433FD11C7D1134009F0876 /* CryptoSwift.swift in Sources */,
 				C38808641C62C0390067DADD /* ResponseTests.swift in Sources */,
+				34CC59671C7DCAE3007CA680 /* Event.swift in Sources */,
 				C352E6F81C62BC6A00E26467 /* ResponseConvertible.swift in Sources */,
 				34CC595B1C7BE405007CA680 /* Log.swift in Sources */,
 				C352E6F01C62BC6A00E26467 /* MemorySessionDriver.swift in Sources */,


### PR DESCRIPTION
This PR proposes a similar event-subscriber system as Laravel. This will allow users to 'hook' into system events, such as errors, or `Fluent` model events, such as `pre-save`, `pre-remove`, as well as allowing users to create their own events.

Users would register subscribers when the application boots that respond to specific events. Note that the `targets` do not subscribe to events and should not need to be deregistered. It is the job of each subscriber to check if it should respond to a particular event. Subscribers are able to define a `priority` that determines the order in which they are processed.

An example is below.

```swift

//A user model
struct User {
    let name: String
}

//Example events fired by Fluent
enum FluentEvents: String, EventType {
    case PreSave, PostSave, PreUpdate, PostUpdate, PreDestroy, PostDestroy...
}

//User's custom defined 
enum MyEvents: String, EventType {
    case CustomEvent...
}

//We create subscribers

let high = Subscriber(FluentEvents.PreSave, priority: 100) { data in    
    guard let user = data as? User else { return }
    print("High Priority - \(user.name) just registered. Do something")
}

let low = Subscriber(FluentEvents.PreSave) { data in
    guard let user = data as? User else { return }
    print("Standard Priority - \(user.name) registered. Stuff has already been done.")
}

let other = Subscriber(MyEvents.CustomEvent) { data in
    print("Custom event - \(data)")
}

//We add the subscribers in main.swift
Subscriber.add([low, high, other])

//Fluent fires an event
let event = Event(FluentEvents.PreSave data: user)
Event.fire(event)

//Subscribers 'high' and 'low' respond to this specific event (in that order).
// The custom subscriber does not respond.

```

