### PR TITLE
Initial Controller Action implementation

### DIFF
--- a/Sources/Application+Route.swift
+++ b/Sources/Application+Route.swift
@@ -93,6 +93,24 @@ extension Application {
         let route = Route(host: host, method: method, path: path, handler: handler)
         self.routes.append(route)
     }
+
+    public final func add<ActionController: Controller>(method: Request.Method, path: String, action: (ActionController) -> () throws -> ResponseConvertible) {
+
+        //Convert Action to Request.Handler
+        var handler = { request in
+            return try action(try ActionController(request: request))().response()
+        }
+
+        //Apply any scoped middlewares
+        for middleware in Route.scopedMiddleware {
+            handler = middleware.handle(handler)
+        }
+
+        //Store the route for registering with Router later
+        let host = Route.scopedHost ?? "*"
+        let route = Route(host: host, method: method, path: path, handler: handler)
+        self.routes.append(route)
+    }
     
     /**
         Applies the middleware to the routes defined

--- a/Sources/Application+Route.swift
+++ b/Sources/Application+Route.swift
@@ -77,36 +77,33 @@ extension Application {
     }
     
     public final func add(method: Request.Method, path: String, handler: Route.Handler) {
-        
-        //Convert Route.Handler to Request.Handler
-        var handler = { request in
+        // Convert Route.Handler to Request.Handler
+        let handler = { request in
             return try handler(request).response()
         }
-        
-        //Apply any scoped middlewares
-        for middleware in Route.scopedMiddleware {
-            handler = middleware.handle(handler)
-        }
-        
-        //Store the route for registering with Router later
-        let host = Route.scopedHost ?? "*"
-        let route = Route(host: host, method: method, path: path, handler: handler)
-        self.routes.append(route)
+
+        add(method, path: path, routeHandler: handler)
     }
 
     public final func add<ActionController: Controller>(method: Request.Method, path: String, action: (ActionController) -> () throws -> ResponseConvertible) {
-
-        //Convert Action to Request.Handler
-        var handler = { request in
+        // Convert Action to Request.Handler
+        let handler = { request in
             return try action(try ActionController(request: request))().response()
         }
 
-        //Apply any scoped middlewares
+        add(method, path: path, routeHandler: handler)
+    }
+
+    private func add(method: Request.Method, path: String, routeHandler: Request.Handler) {
+        // Make handler writable
+        var handler = routeHandler
+
+        // Apply any scoped middlewares
         for middleware in Route.scopedMiddleware {
             handler = middleware.handle(handler)
         }
 
-        //Store the route for registering with Router later
+        // Store the route for registering with Router later
         let host = Route.scopedHost ?? "*"
         let route = Route(host: host, method: method, path: path, handler: handler)
         self.routes.append(route)

--- a/Sources/Application+Route.swift
+++ b/Sources/Application+Route.swift
@@ -46,14 +46,14 @@ extension Application {
     
     /**
         Creates standard Create, Read, Update, Delete routes
-        using the Handlers from a supplied `Controller`.
+        using the Handlers from a supplied `ResourcesController`.
      
         The `path` supports nested resources, like `users.photos`.
         users/:user_id/photos/:id
      
         Note: You are responsible for pluralizing your endpoints.
     */
-    public final func resource(path: String, controller: Controller) {
+    public final func resource(path: String, controller: ResourcesController) {
 
         let last = "/:id"
         

--- a/Sources/Controller.swift
+++ b/Sources/Controller.swift
@@ -1,0 +1,12 @@
+//
+//  Controller.swift
+//  Vapor
+//
+//  Created by James Richard on 2/24/16.
+//  Copyright © 2016 Tanner Nelson. All rights reserved.
+//
+
+public protocol Controller: class {
+    var request: Request { get }
+    init(request: Request) throws
+}

--- a/Sources/ResourcesController.swift
+++ b/Sources/ResourcesController.swift
@@ -6,7 +6,7 @@
  */
 public protocol ResourcesController {
     /// Display many instances
-	func index(request: Request) throws -> ResponseConvertible
+    func index(request: Request) throws -> ResponseConvertible
 
     /// Create a new instance.
     func store(request: Request) throws -> ResponseConvertible

--- a/Sources/ResourcesController.swift
+++ b/Sources/ResourcesController.swift
@@ -1,10 +1,10 @@
 /**
  * Organize your routing logic with a conformance of
- * `Controller`. Controls group related route logic into
+ * `ResourcesController`. Controls group related route logic into
  * a single protocol that, by default, conforms to standard
  * CRUD operations.
  */
-public protocol Controller {
+public protocol ResourcesController {
     /// Display many instances
 	func index(request: Request) throws -> ResponseConvertible
 

--- a/Tests/ControllerTests.swift
+++ b/Tests/ControllerTests.swift
@@ -1,5 +1,5 @@
 //
-//  RouteTests.swift
+//  ResourcesControllerTests.swift
 //  Vapor
 //
 //  Created by Matthew on 20/02/2016.
@@ -8,9 +8,9 @@
 
 import XCTest
 
-class ControllerTests: XCTestCase {
+class ResourcesControllerTests: XCTestCase {
     
-    class TestController: Controller {
+    class TestController: ResourcesController {
         
         var lock: (
             index: Int,

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -37,8 +37,8 @@
 		C3433FD41C7D119D009F0876 /* HashTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3433FD21C7D119D009F0876 /* HashTests.swift */; };
 		C3433FD61C7D1203009F0876 /* SHA256Hasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3433FD51C7D1203009F0876 /* SHA256Hasher.swift */; };
 		C3433FD71C7D1203009F0876 /* SHA256Hasher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3433FD51C7D1203009F0876 /* SHA256Hasher.swift */; };
-		C352E6E71C62BC6A00E26467 /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D31C62BC6A00E26467 /* Controller.swift */; };
-		C352E6E81C62BC6A00E26467 /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D31C62BC6A00E26467 /* Controller.swift */; };
+		C352E6E71C62BC6A00E26467 /* ResourcesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D31C62BC6A00E26467 /* ResourcesController.swift */; };
+		C352E6E81C62BC6A00E26467 /* ResourcesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D31C62BC6A00E26467 /* ResourcesController.swift */; };
 		C352E6E91C62BC6A00E26467 /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D41C62BC6A00E26467 /* JSONSerializer.swift */; };
 		C352E6EA1C62BC6A00E26467 /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D41C62BC6A00E26467 /* JSONSerializer.swift */; };
 		C352E6EB1C62BC6A00E26467 /* LinuxFixes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D51C62BC6A00E26467 /* LinuxFixes.swift */; };
@@ -116,7 +116,7 @@
 		C352E6811C62BB0F00E26467 /* Vapor */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Vapor; sourceTree = BUILT_PRODUCTS_DIR; };
 		C352E68F1C62BB1C00E26467 /* Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		C352E6931C62BB1C00E26467 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C352E6D31C62BC6A00E26467 /* Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
+		C352E6D31C62BC6A00E26467 /* ResourcesController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResourcesController.swift; sourceTree = "<group>"; };
 		C352E6D41C62BC6A00E26467 /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
 		C352E6D51C62BC6A00E26467 /* LinuxFixes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LinuxFixes.swift; sourceTree = "<group>"; };
 		C352E6D71C62BC6A00E26467 /* MemorySessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MemorySessionDriver.swift; sourceTree = "<group>"; };
@@ -262,7 +262,7 @@
 			isa = PBXGroup;
 			children = (
 				C364C5001C7EB579009F65DD /* Route.swift */,
-				C352E6D31C62BC6A00E26467 /* Controller.swift */,
+				C352E6D31C62BC6A00E26467 /* ResourcesController.swift */,
 				C3433FCC1C7CFB4C009F0876 /* Application+Route.swift */,
 			);
 			name = Routing;
@@ -497,7 +497,7 @@
 				C352E6E91C62BC6A00E26467 /* JSONSerializer.swift in Sources */,
 				802030011C77C956009B8655 /* Vapor+JSON.swift in Sources */,
 				C352E6EB1C62BC6A00E26467 /* LinuxFixes.swift in Sources */,
-				C352E6E71C62BC6A00E26467 /* Controller.swift in Sources */,
+				C352E6E71C62BC6A00E26467 /* ResourcesController.swift in Sources */,
 				C304C8A71C62D65200058C92 /* ServerDriver.swift in Sources */,
 				C352E6F71C62BC6A00E26467 /* ResponseConvertible.swift in Sources */,
 				802030121C78CAC2009B8655 /* Branch.swift in Sources */,
@@ -520,7 +520,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				C352E7021C62BC6A00E26467 /* Socket.swift in Sources */,
-				C352E6E81C62BC6A00E26467 /* Controller.swift in Sources */,
+				C352E6E81C62BC6A00E26467 /* ResourcesController.swift in Sources */,
 				C304C8B61C6306B100058C92 /* RouterDriver.swift in Sources */,
 				C352E6EC1C62BC6A00E26467 /* LinuxFixes.swift in Sources */,
 				C3433FD11C7D1134009F0876 /* CryptoSwift.swift in Sources */,

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A6FDF651C7ED71700B0529C /* Controller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6FDF641C7ED71700B0529C /* Controller.swift */; };
 		288CFC2E1C7AC01A00E4617A /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288CFC2D1C7AC01A00E4617A /* Application.swift */; };
 		288CFC311C7AC02A00E4617A /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288CFC301C7AC02A00E4617A /* Provider.swift */; };
 		288CFC321C7AC05B00E4617A /* Application.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288CFC2D1C7AC01A00E4617A /* Application.swift */; };
@@ -94,6 +95,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A6FDF641C7ED71700B0529C /* Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Controller.swift; sourceTree = "<group>"; };
 		288CFC2D1C7AC01A00E4617A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Application.swift; sourceTree = "<group>"; };
 		288CFC301C7AC02A00E4617A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Provider.swift; sourceTree = "<group>"; };
 		3492B2EE1C787DD600D8E588 /* RouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RouteTests.swift; sourceTree = "<group>"; };
@@ -264,6 +266,7 @@
 				C364C5001C7EB579009F65DD /* Route.swift */,
 				C352E6D31C62BC6A00E26467 /* ResourcesController.swift */,
 				C3433FCC1C7CFB4C009F0876 /* Application+Route.swift */,
+				1A6FDF641C7ED71700B0529C /* Controller.swift */,
 			);
 			name = Routing;
 			sourceTree = "<group>";
@@ -498,6 +501,7 @@
 				802030011C77C956009B8655 /* Vapor+JSON.swift in Sources */,
 				C352E6EB1C62BC6A00E26467 /* LinuxFixes.swift in Sources */,
 				C352E6E71C62BC6A00E26467 /* ResourcesController.swift in Sources */,
+				1A6FDF651C7ED71700B0529C /* Controller.swift in Sources */,
 				C304C8A71C62D65200058C92 /* ServerDriver.swift in Sources */,
 				C352E6F71C62BC6A00E26467 /* ResponseConvertible.swift in Sources */,
 				802030121C78CAC2009B8655 /* Branch.swift in Sources */,


### PR DESCRIPTION
This is the first pass towards routes that can operate on controller actions.

I changed `Controller` to `ResourcesController` as it better describes what it was doing, and replaced the `Controller` protocol with the definition that supports `Request` passing into the initializer. Here's an example of using the new API:

```
class TestController: Controller {
    let request: Request

    required init(request: Request) throws {
        self.request = request
    }

    func derp() throws -> ResponseConvertible {
        return "Hai"
    }
}

app.add(.Get, path: "/derp", action: TestController.derp)
```

I'd like to have `ResourcesController` be a subprotocol of `Controller`, but I felt like it was a bit much to do in one pass. `ResourcesController`, under the current setup, ends up using the same instance for every request after being used with `app.resource`, which I don't think is desired and would be fixed in the same pass.

I'm also DRY'ing up some routing code through a private method now that the same thing was being done three times.