### PR TITLE
Convert SessionDriver to a conformable protocol

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -44,7 +44,7 @@ public class Request {
     public var parameters: [String: String] = [:]
     
     ///Server stored information related from session cookie.
-    public var session: Session = Session()
+    public let session = Session()
     
     ///Requested hostname
     public let hostname: String

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -10,19 +10,29 @@ public class MemorySessionDriver: SessionDriver {
 
     public init() { }
 
-    public func valueForKey(key: String, inSessionIdentifiedBy sessionIdentifier: String) -> String? {
+    public func valueFor(key key: String, inSession session: Session) -> String? {
+        guard let sessionIdentifier = session.sessionIdentifier else {
+            Log.warning("Unable to read a value for '\(key)': The session has not been registered yet")
+            return nil
+        }
+
         return sessions[sessionIdentifier]?[key]
     }
 
-    public func setValue(value: String?, forKey key: String, inSessionIdentifiedBy sessionIdentifier: String) {
+    public func set(value value: String?, forKey key: String, inSession session: Session) {
+        guard let sessionIdentifier = session.sessionIdentifier else {
+            Log.warning("Unable to store a value for '\(key)': The session has not been registered yet")
+            return
+        }
+
         if sessions[sessionIdentifier] == nil {
             sessions[sessionIdentifier] = [String: String]()
         }
 
-        sessions[sessionIdentifier]![key] = value
+        sessions[sessionIdentifier]?[key] = value
     }
 
-    public var randomSessionIdentifier: String {
+    public func newSessionIdentifier() -> String {
         var identifier = String(NSDate().timeIntervalSinceNow)
         identifier += "v@p0r"
         identifier += String(Int.random(min: 0, max: 9999))
@@ -33,7 +43,12 @@ public class MemorySessionDriver: SessionDriver {
         return Hash.make(identifier)
     }
 
-    public func destroySessionIdentifiedBy(sessionIdentifier: String) {
+    public func destroy(session session: Session) {
+        guard let sessionIdentifier = session.sessionIdentifier else {
+            Log.warning("Unable to destroy the session: The session has not been registered yet")
+            return
+        }
+
         sessions[sessionIdentifier] = nil
     }
 }

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -1,8 +1,39 @@
+import Foundation
+
 /**
  * The `MemorySessionDriver` stores session data
  * in a Swift `Dictionary`. This means all session
  * data will be purged if the server is restarted.
  */
-class MemorySessionDriver: SessionDriver {
-	var sessions = [String: Session]()
+public class MemorySessionDriver: SessionDriver {
+    var sessions = [String: [String: String]]()
+
+    public init() { }
+
+    public func valueForKey(key: String, inSessionIdentifiedBy sessionIdentifier: String) -> String? {
+        return sessions[sessionIdentifier]?[key]
+    }
+
+    public func setValue(value: String?, forKey key: String, inSessionIdentifiedBy sessionIdentifier: String) {
+        if sessions[sessionIdentifier] == nil {
+            sessions[sessionIdentifier] = [String: String]()
+        }
+
+        sessions[sessionIdentifier]![key] = value
+    }
+
+    public func createSessionIdentifier() -> String {
+        var identifier = String(NSDate().timeIntervalSinceNow)
+        identifier += "v@p0r"
+        identifier += String(Int.random(min: 0, max: 9999))
+        identifier += "s3sS10n"
+        identifier += String(Int.random(min: 0, max: 9999))
+        identifier += "k3y"
+        identifier += String(Int.random(min: 0, max: 9999))
+        return Hash.make(identifier)
+    }
+
+    public func destroySessionIdentifiedBy(sessionIdentifier: String) {
+        sessions[sessionIdentifier] = nil
+    }
 }

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -22,7 +22,7 @@ public class MemorySessionDriver: SessionDriver {
         sessions[sessionIdentifier]![key] = value
     }
 
-    public func createSessionIdentifier() -> String {
+    public var randomSessionIdentifier: String {
         var identifier = String(NSDate().timeIntervalSinceNow)
         identifier += "v@p0r"
         identifier += String(Int.random(min: 0, max: 9999))

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -11,7 +11,7 @@ public class MemorySessionDriver: SessionDriver {
     public init() { }
 
     public func valueFor(key key: String, inSession session: Session) -> String? {
-        guard let sessionIdentifier = session.sessionIdentifier else {
+        guard let sessionIdentifier = session.identifier else {
             Log.warning("Unable to read a value for '\(key)': The session has not been registered yet")
             return nil
         }
@@ -20,7 +20,7 @@ public class MemorySessionDriver: SessionDriver {
     }
 
     public func set(value: String?, forKey key: String, inSession session: Session) {
-        guard let sessionIdentifier = session.sessionIdentifier else {
+        guard let sessionIdentifier = session.identifier else {
             Log.warning("Unable to store a value for '\(key)': The session has not been registered yet")
             return
         }
@@ -44,7 +44,7 @@ public class MemorySessionDriver: SessionDriver {
     }
 
     public func destroy(session: Session) {
-        guard let sessionIdentifier = session.sessionIdentifier else {
+        guard let sessionIdentifier = session.identifier else {
             Log.warning("Unable to destroy the session: The session has not been registered yet")
             return
         }

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -19,7 +19,7 @@ public class MemorySessionDriver: SessionDriver {
         return sessions[sessionIdentifier]?[key]
     }
 
-    public func set(value value: String?, forKey key: String, inSession session: Session) {
+    public func set(value: String?, forKey key: String, inSession session: Session) {
         guard let sessionIdentifier = session.sessionIdentifier else {
             Log.warning("Unable to store a value for '\(key)': The session has not been registered yet")
             return
@@ -43,7 +43,7 @@ public class MemorySessionDriver: SessionDriver {
         return Hash.make(identifier)
     }
 
-    public func destroy(session session: Session) {
+    public func destroy(session: Session) {
         guard let sessionIdentifier = session.sessionIdentifier else {
             Log.warning("Unable to destroy the session: The session has not been registered yet")
             return

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -1,82 +1,40 @@
-import Foundation
-
-protocol SessionDriver {
-	var sessions: [String: Session] { get set }
-}
 
 public class Session {
 
-	public enum DriverType {
-		case File, Memory
-	}
-	public static var type: DriverType = .Memory {
-		didSet {
-			switch self.type {
-				case .Memory:
-					self.driver = MemorySessionDriver()
-				case .File:
-					fatalError("File driver not yet supported")
-			}
-		}
-	}
-	static var driver: SessionDriver = MemorySessionDriver()
+	public static var driver: SessionDriver = MemorySessionDriver()
 
-	public static func start(request: Request) {
-		if let key = request.cookies["vapor-session"] {
-			if let session = self.driver.sessions[key] {
-				request.session = session
-			} else {
-				request.session.key = key
-				self.driver.sessions[key] = request.session
-			}
-		}
-	}
-
-	public static func close(request request: Request, response: Response) {
-		if let key = request.session.key {
-			response.cookies["vapor-session"] = key
-		} 
-	}
+    var sessionIdentifier: String?
 
 	init() {
 		//do nothing
 	}
 
 	public func destroy() {
-		if let key = self.key {
-			Session.driver.sessions.removeValueForKey(key)
-		}
+        guard let sessionIdentifier = sessionIdentifier else {
+            Log.warning("Unable to destroy the session: The session has not be registered yet")
+            return
+        }
+
+        Session.driver.destroySessionIdentifiedBy(sessionIdentifier)
 	}
 
     public subscript(key: String) -> String? {
         get {
-            return data[key]
+            guard let sessionIdentifier = sessionIdentifier else {
+                Log.warning("Unable to read a value for '\(key)': The session has not be registered yet")
+                return nil
+            }
+
+            return Session.driver.valueForKey(key, inSessionIdentifiedBy: sessionIdentifier)
         }
 
         set(newValue) {
-            data[key] = newValue
+            guard let sessionIdentifier = sessionIdentifier else {
+                Log.warning("Unable to store a value for '\(key)': The session has not be registered yet")
+                return
+            }
+
+            Session.driver.setValue(newValue, forKey: key, inSessionIdentifiedBy: sessionIdentifier)
         }
     }
-
-	var key: String?
-	var data: [String: String] = [:] {
-		didSet {
-			if self.key == nil {
-                
-				var key = "\(NSDate().timeIntervalSinceNow)"
-                key += "v@p0r"
-                key += "\(Int.random(min: 0, max: 9999))"
-                key += "s3sS10n"
-                key += "\(Int.random(min: 0, max: 9999))"
-                key += "k3y"
-                key += "\(Int.random(min: 0, max: 9999))"
-                
-                key = Hash.make(key)
-                
-				self.key = key
-				Session.driver.sessions[key] = self
-			}
-		}
-	}
-
 }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -1,7 +1,7 @@
 
 public class Session {
 
-	public static var driver: SessionDriver = MemorySessionDriver()
+    public static var driver: SessionDriver = MemorySessionDriver()
 
     var sessionIdentifier: String?
 

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -3,7 +3,7 @@ public class Session {
 
     public static var driver: SessionDriver = MemorySessionDriver()
 
-    var sessionIdentifier: String?
+    public internal(set) var identifier: String?
 
 	init() {
 		//do nothing

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -10,31 +10,16 @@ public class Session {
 	}
 
 	public func destroy() {
-        guard let sessionIdentifier = sessionIdentifier else {
-            Log.warning("Unable to destroy the session: The session has not be registered yet")
-            return
-        }
-
-        Session.driver.destroySessionIdentifiedBy(sessionIdentifier)
+        Session.driver.destroy(session: self)
 	}
 
     public subscript(key: String) -> String? {
         get {
-            guard let sessionIdentifier = sessionIdentifier else {
-                Log.warning("Unable to read a value for '\(key)': The session has not be registered yet")
-                return nil
-            }
-
-            return Session.driver.valueForKey(key, inSessionIdentifiedBy: sessionIdentifier)
+            return Session.driver.valueFor(key: key, inSession: self)
         }
 
-        set(newValue) {
-            guard let sessionIdentifier = sessionIdentifier else {
-                Log.warning("Unable to store a value for '\(key)': The session has not be registered yet")
-                return
-            }
-
-            Session.driver.setValue(newValue, forKey: key, inSessionIdentifiedBy: sessionIdentifier)
+        set {
+            Session.driver.set(value: newValue, forKey: key, inSession: self)
         }
     }
 }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -10,7 +10,7 @@ public class Session {
 	}
 
 	public func destroy() {
-        Session.driver.destroy(session: self)
+        Session.driver.destroy(self)
 	}
 
     public subscript(key: String) -> String? {
@@ -19,7 +19,7 @@ public class Session {
         }
 
         set {
-            Session.driver.set(value: newValue, forKey: key, inSession: self)
+            Session.driver.set(newValue, forKey: key, inSession: self)
         }
     }
 }

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -1,0 +1,6 @@
+public protocol SessionDriver: class {
+    func valueForKey(key: String, inSessionIdentifiedBy sessionIdentifier: String) -> String?
+    func setValue(value: String?, forKey key: String, inSessionIdentifiedBy sessionIdentifier: String)
+    func createSessionIdentifier() -> String
+    func destroySessionIdentifiedBy(sessionIdentifier: String)
+}

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -1,6 +1,6 @@
 public protocol SessionDriver: class {
-    var randomSessionIdentifier: String
-    func valueForKey(key: String, inSessionIdentifiedBy sessionIdentifier: String) -> String?
-    func setValue(value: String?, forKey key: String, inSessionIdentifiedBy sessionIdentifier: String)
-    func destroySessionIdentifiedBy(sessionIdentifier: String)
+    func newSessionIdentifier() -> String
+    func valueFor(key key: String, inSession session: Session) -> String?
+    func set(value value: String?, forKey key: String, inSession session: Session)
+    func destroy(session session: Session)
 }

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -1,6 +1,6 @@
 public protocol SessionDriver: class {
+    var randomSessionIdentifier: String
     func valueForKey(key: String, inSessionIdentifiedBy sessionIdentifier: String) -> String?
     func setValue(value: String?, forKey key: String, inSessionIdentifiedBy sessionIdentifier: String)
-    func createSessionIdentifier() -> String
     func destroySessionIdentifiedBy(sessionIdentifier: String)
 }

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -1,6 +1,6 @@
 public protocol SessionDriver: class {
     func newSessionIdentifier() -> String
     func valueFor(key key: String, inSession session: Session) -> String?
-    func set(value value: String?, forKey key: String, inSession session: Session)
-    func destroy(session session: Session)
+    func set(value: String?, forKey key: String, inSession session: Session)
+    func destroy(session: Session)
 }

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -3,7 +3,7 @@ class SessionMiddleware: Middleware {
     static func handle(handler: Request.Handler) -> Request.Handler {
         return { request in
             let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.newSessionIdentifier()
-            request.session.sessionIdentifier = sessionIdentifier
+            request.session.identifier = sessionIdentifier
 
             let response = try handler(request: request)
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -2,11 +2,12 @@ class SessionMiddleware: Middleware {
 
     static func handle(handler: Request.Handler) -> Request.Handler {
         return { request in
-            Session.start(request)
+            let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.createSessionIdentifier()
+            request.session.sessionIdentifier = sessionIdentifier
 
             let response = try handler(request: request)
-            
-            Session.close(request: request, response: response)
+
+            response.cookies["vapor-session"] = sessionIdentifier
 
             return response
         }

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -2,7 +2,7 @@ class SessionMiddleware: Middleware {
 
     static func handle(handler: Request.Handler) -> Request.Handler {
         return { request in
-            let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.createSessionIdentifier()
+            let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.newSessionIdentifier()
             request.session.sessionIdentifier = sessionIdentifier
 
             let response = try handler(request: request)

--- a/XcodeProject/Vapor.xcodeproj/project.pbxproj
+++ b/XcodeProject/Vapor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1AC8BC7C1C84B5A500BAC14E /* MemorySessionDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */; };
 		3492B2EF1C787DD600D8E588 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EE1C787DD600D8E588 /* RouteTests.swift */; };
 		34CC59561C7BE3C9007CA680 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59551C7BE3C9007CA680 /* LogTests.swift */; };
 		3A583A011C7FCA720044AAFF /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A583A001C7FCA720044AAFF /* libVapor.dylib */; };
@@ -36,7 +37,7 @@
 		3A91D3E91C7F6B6600EA3CA0 /* SocketParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D81C62BC6A00E26467 /* SocketParser.swift */; };
 		3A91D3EA1C7F6B6600EA3CA0 /* ServerDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C304C8A61C62D65200058C92 /* ServerDriver.swift */; };
 		3A91D3EB1C7F6B6600EA3CA0 /* Session.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6DF1C62BC6A00E26467 /* Session.swift */; };
-		3A91D3EC1C7F6B6600EA3CA0 /* MemorySessionDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D71C62BC6A00E26467 /* MemorySessionDriver.swift */; };
+		3A91D3EC1C7F6B6600EA3CA0 /* SessionDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C352E6D71C62BC6A00E26467 /* SessionDriver.swift */; };
 		3A91D3ED1C7F6B6600EA3CA0 /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EDEA7A1C683A6C00754727 /* Middleware.swift */; };
 		3A91D3EE1C7F6B6600EA3CA0 /* SessionMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3EDEA7C1C683CE100754727 /* SessionMiddleware.swift */; };
 		3A91D3EF1C7F6B6600EA3CA0 /* Provider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 288CFC301C7AC02A00E4617A /* Provider.swift */; };
@@ -83,6 +84,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemorySessionDriver.swift; path = ../Sources/Vapor/Session/MemorySessionDriver.swift; sourceTree = "<group>"; };
 		288CFC2D1C7AC01A00E4617A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Application.swift; path = ../Sources/Vapor/Core/Application.swift; sourceTree = SOURCE_ROOT; };
 		288CFC301C7AC02A00E4617A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Provider.swift; path = ../Sources/Vapor/Core/Provider.swift; sourceTree = SOURCE_ROOT; };
 		3492B2EE1C787DD600D8E588 /* RouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteTests.swift; path = ../Tests/Vapor/RouteTests.swift; sourceTree = SOURCE_ROOT; };
@@ -118,7 +120,7 @@
 		C352E6D31C62BC6A00E26467 /* Controller.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Controller.swift; path = ../Sources/Vapor/Routing/Controller.swift; sourceTree = SOURCE_ROOT; };
 		C352E6D41C62BC6A00E26467 /* JSONSerializer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = JSONSerializer.swift; path = ../Sources/Vapor/JSON/JSONSerializer.swift; sourceTree = SOURCE_ROOT; };
 		C352E6D51C62BC6A00E26467 /* LinuxFixes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = LinuxFixes.swift; path = ../Sources/Vapor/Fixes/LinuxFixes.swift; sourceTree = SOURCE_ROOT; };
-		C352E6D71C62BC6A00E26467 /* MemorySessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemorySessionDriver.swift; path = ../Sources/Vapor/Session/MemorySessionDriver.swift; sourceTree = SOURCE_ROOT; };
+		C352E6D71C62BC6A00E26467 /* SessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SessionDriver.swift; path = ../Sources/Vapor/Session/SessionDriver.swift; sourceTree = SOURCE_ROOT; };
 		C352E6D81C62BC6A00E26467 /* SocketParser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SocketParser.swift; path = ../Sources/Vapor/Server/SocketParser.swift; sourceTree = SOURCE_ROOT; };
 		C352E6D91C62BC6A00E26467 /* Request.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Request.swift; path = ../Sources/Vapor/Request/Request.swift; sourceTree = SOURCE_ROOT; };
 		C352E6DA1C62BC6A00E26467 /* Response.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Response.swift; path = ../Sources/Vapor/Response/Response.swift; sourceTree = SOURCE_ROOT; };
@@ -279,8 +281,9 @@
 		C304C8AE1C63050900058C92 /* Session */ = {
 			isa = PBXGroup;
 			children = (
+				1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */,
 				C352E6DF1C62BC6A00E26467 /* Session.swift */,
-				C352E6D71C62BC6A00E26467 /* MemorySessionDriver.swift */,
+				C352E6D71C62BC6A00E26467 /* SessionDriver.swift */,
 			);
 			name = Session;
 			path = ../Sources;
@@ -645,8 +648,9 @@
 				3A91D3EB1C7F6B6600EA3CA0 /* Session.swift in Sources */,
 				3A91D3D71C7F6B6600EA3CA0 /* Application.swift in Sources */,
 				3A91D3E11C7F6B6600EA3CA0 /* RouterDriver.swift in Sources */,
-				3A91D3EC1C7F6B6600EA3CA0 /* MemorySessionDriver.swift in Sources */,
+				3A91D3EC1C7F6B6600EA3CA0 /* SessionDriver.swift in Sources */,
 				3A91D3F31C7F6B6600EA3CA0 /* CryptoSwift.swift in Sources */,
+				1AC8BC7C1C84B5A500BAC14E /* MemorySessionDriver.swift in Sources */,
 				3A91D3D81C7F6B6600EA3CA0 /* Route.swift in Sources */,
 				3A91D3ED1C7F6B6600EA3CA0 /* Middleware.swift in Sources */,
 				3A91D3E31C7F6B6600EA3CA0 /* RequestFormExtension.swift in Sources */,


### PR DESCRIPTION
This moves all of the logic for storing session information into a type that conforms to `SessionDriver`. An application can update the session driver at the start of their application by calling `Session.driver = [YourSessionDriverType]()`. The `Session` class is refactored some to delegate value fetching & updating, and session destruction to the `SessionDriver`. Session identifiers have also been moved over to the `SessionDriver` class so driver writers can decide how best to determine key their sessions.