### PR TITLE
Configures proper test running for Xcode

### DIFF
--- a/XcodeProject/Vapor.xcodeproj/xcshareddata/xcschemes/Vapor.xcscheme
+++ b/XcodeProject/Vapor.xcodeproj/xcshareddata/xcschemes/Vapor.xcscheme
@@ -29,7 +29,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "C352E68E1C62BB1C00E26467"
+               BuildableName = "Tests.xctest"
+               BlueprintName = "Tests"
+               ReferencedContainer = "container:Vapor.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "3A91D3CB1C7F6AF900EA3CA0"
+            BuildableName = "Vapor.framework"
+            BlueprintName = "Vapor"
+            ReferencedContainer = "container:Vapor.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>


### PR DESCRIPTION
This does two things:

1. Removes "Tests" from the list of runnable Scheme's in Xcode. These are usually hidden.
2. Adds "Tests" as a tested bundle for "Vapor"; This will cause Vapor to be built before hand, and then run the "Tests" bundle.

This is how I've seen every other project work. You want to test the framework you are working on, you can just Cmd+U on it, and it'll run the associated tests. :)