### PR TITLE
Moves scoped properties onto the Application instance

### DIFF
--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -52,6 +52,10 @@ public class Application {
 		}
 	}
 
+    var scopedHost: String?
+    var scopedMiddleware: [Middleware.Type] = []
+    var scopedPrefix: String?
+
 	var port: Int = 80
 	
 	var routes: [Route] = []

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -81,16 +81,16 @@ extension Application {
         }
         
         //Apply any scoped middlewares
-        for middleware in Route.scopedMiddleware {
+        for middleware in scopedMiddleware {
             handler = middleware.handle(handler)
         }
         
         //Store the route for registering with Router later
-        let host = Route.scopedHost ?? "*"
+        let host = scopedHost ?? "*"
         
         //Apply any scoped prefix
         var path = path
-        if let prefix = Route.scopedPrefix {
+        if let prefix = scopedPrefix {
             path = prefix + "/" + path
         }
         
@@ -108,21 +108,21 @@ extension Application {
     }
     
     public final func middleware(middleware: [Middleware.Type], handler: () -> ()) {
-        let original = Route.scopedMiddleware
-        Route.scopedMiddleware += middleware
+        let original = scopedMiddleware
+        scopedMiddleware += middleware
         
         handler()
         
-        Route.scopedMiddleware = original
+        scopedMiddleware = original
     }
     
     public final func host(host: String, handler: () -> Void) {
-        let original = Route.scopedHost
-        Route.scopedHost = host
+        let original = scopedHost
+        scopedHost = host
         
         handler()
         
-        Route.scopedHost = original
+        scopedHost = original
     }
     
     /**
@@ -130,17 +130,17 @@ extension Application {
         without repeating yourself.
     */
     public func group(prefix: String, @noescape handler: () -> Void) {
-        let original = Route.scopedPrefix
+        let original = scopedPrefix
         
         //append original with a trailing slash
         if let original = original {
-            Route.scopedPrefix = original + "/" + prefix
+            scopedPrefix = original + "/" + prefix
         } else {
-            Route.scopedPrefix = prefix
+            scopedPrefix = prefix
         }
         
         handler()
         
-        Route.scopedPrefix = original
+        scopedPrefix = original
     }
 }

--- a/Sources/Vapor/Routing/Route.swift
+++ b/Sources/Vapor/Routing/Route.swift
@@ -10,12 +10,6 @@ public class Route {
      */
     public typealias Handler = Request throws -> ResponseConvertible
 
-    // MARK: Internal State
-    
-    internal static var scopedHost: String?
-    internal static var scopedMiddleware: [Middleware.Type] = []
-    internal static var scopedPrefix: String?
-
     // MARK: Attributes
     
     let method: Request.Method


### PR DESCRIPTION
This reduces the amount of shared state Vapor types have. It seemed to make sense since all the scoped stuff was being read and written to within an Application's instance methods.