### PR TITLE
Adds the ability to define Middleware that should be ran on a specific controller

### DIFF
--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -53,7 +53,7 @@ extension Application {
      
         Note: You are responsible for pluralizing your endpoints.
     */
-    public final func resource(path: String, controller: ResourceController.Type) {
+    public final func resource<RoutedController: ResourceController>(path: String, controller: RoutedController.Type) {
         let last = "/:id"
         let shortPath = path.componentsSeparatedByString(".")
             .flatMap { component in
@@ -64,13 +64,27 @@ extension Application {
         let fullPath = shortPath + last
         
         // ie: /users
-        self.get(shortPath) { try controller.init().index($0) }
-        self.post(shortPath) { try controller.init().store($0) }
-        
+        self.add(.Get, path: shortPath, action: RoutedController.index)
+        self.add(.Post, path: shortPath, action: RoutedController.store)
+
         // ie: /users/:id
-        self.get(fullPath) { try controller.init().show($0) }
-        self.put(fullPath) { try controller.init().update($0) }
-        self.delete(fullPath) { try controller.init().destroy($0) }
+        self.add(.Get, path: fullPath, action: RoutedController.show)
+        self.add(.Put, path: fullPath, action: RoutedController.update)
+        self.add(.Delete, path: fullPath, action: RoutedController.destroy)
+    }
+
+    public final func add<RoutedController: Controller>(method: Request.Method, path: String, action: (RoutedController) -> (Request) throws -> ResponseConvertible) {
+        var handler: Request.Handler = { request in
+            let controller = RoutedController()
+            let actionCall = action(controller)
+            return try actionCall(request).response()
+        }
+
+        for mw in RoutedController.middleware {
+            handler = mw.handle(handler)
+        }
+
+        add(method, path: path, handler: handler)
     }
     
     public final func add(method: Request.Method, path: String, handler: Route.Handler) {

--- a/Sources/Vapor/Routing/Controller.swift
+++ b/Sources/Vapor/Routing/Controller.swift
@@ -2,4 +2,12 @@ import Foundation
 
 public protocol Controller {
     init()
+    static var middleware: [Middleware.Type] { get }
 }
+
+extension Controller {
+    public static var middleware: [Middleware.Type] {
+        return []
+    }
+}
+

--- a/Sources/VaporDev/Controllers/FooController.swift
+++ b/Sources/VaporDev/Controllers/FooController.swift
@@ -3,7 +3,6 @@
 //  Vapor
 //
 //  Created by James Richard on 3/1/16.
-//  Copyright © 2016 Tanner Nelson. All rights reserved.
 //
 
 import Vapor

--- a/Sources/VaporDev/Controllers/FooController.swift
+++ b/Sources/VaporDev/Controllers/FooController.swift
@@ -1,0 +1,31 @@
+//
+//  FooController.swift
+//  Vapor
+//
+//  Created by James Richard on 3/1/16.
+//  Copyright © 2016 Tanner Nelson. All rights reserved.
+//
+
+import Vapor
+
+class FooController: Controller {
+    required init() { }
+
+    func foo(request: Request) throws -> ResponseConvertible {
+        return "foo"
+    }
+
+    static var middleware: [Middleware.Type] {
+        return [BarMiddleware.self]
+    }
+}
+
+class BarMiddleware: Middleware {
+    static func handle(handler: Request.Handler) -> Request.Handler {
+        return { request in
+            let originalResponse = try handler(request: request)
+            let response = Response(status: originalResponse.status, data: originalResponse.data + " bar".utf8.map({ $0 as UInt8 }), contentType: originalResponse.contentType)
+            return response
+        }
+    }
+}

--- a/Sources/VaporDev/main.swift
+++ b/Sources/VaporDev/main.swift
@@ -54,4 +54,6 @@ app.group("abort") {
     }
 }
 
+app.add(.Get, path: "foo", action: FooController.foo)
+
 app.start(port: 8080)

--- a/XcodeProject/Vapor.xcodeproj/project.pbxproj
+++ b/XcodeProject/Vapor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A475B091C8663AB008E4F98 /* FooController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A475B081C8663AB008E4F98 /* FooController.swift */; };
 		3492B2EF1C787DD600D8E588 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EE1C787DD600D8E588 /* RouteTests.swift */; };
 		34CC59561C7BE3C9007CA680 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59551C7BE3C9007CA680 /* LogTests.swift */; };
 		3A583A011C7FCA720044AAFF /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A583A001C7FCA720044AAFF /* libVapor.dylib */; };
@@ -83,6 +84,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A475B081C8663AB008E4F98 /* FooController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FooController.swift; sourceTree = "<group>"; };
 		288CFC2D1C7AC01A00E4617A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Application.swift; path = ../Sources/Vapor/Core/Application.swift; sourceTree = SOURCE_ROOT; };
 		288CFC301C7AC02A00E4617A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Provider.swift; path = ../Sources/Vapor/Core/Provider.swift; sourceTree = SOURCE_ROOT; };
 		3492B2EE1C787DD600D8E588 /* RouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteTests.swift; path = ../Tests/Vapor/RouteTests.swift; sourceTree = SOURCE_ROOT; };
@@ -393,6 +395,7 @@
 		C3DFB5531C80C2860045801C /* Controllers */ = {
 			isa = PBXGroup;
 			children = (
+				1A475B081C8663AB008E4F98 /* FooController.swift */,
 				C3DFB5541C80C2860045801C /* MyController.swift */,
 			);
 			name = Controllers;
@@ -665,6 +668,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3AEEF4531C7F72C30099CBAE /* main.swift in Sources */,
+				1A475B091C8663AB008E4F98 /* FooController.swift in Sources */,
 				C3DFB55D1C80C2860045801C /* MyController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
Open to comments on this one. This particular feature is inspired by Rails before_filter and Laravel's Controller Middleware. It opens the doors for certain controllers to be behind a logged in user, while others open to everyone. This is a very common need in most web applications, and I'm sure there are plenty more usecases where you'd want a middleware to run on only a certain controller.