### PR TITLE
Convert some Response properties to var

### DIFF
--- a/Sources/Vapor/Response/Response.swift
+++ b/Sources/Vapor/Response/Response.swift
@@ -122,9 +122,9 @@ public class Response {
     
     // MARK: Member Variables
 
-    public let status: Status
-    public let data: [UInt8]
-    public let contentType: ContentType
+    public var status: Status
+    public var data: [UInt8]
+    public var contentType: ContentType
     public var headers: [String : String] = [:]
     
     public var cookies: [String : String] = [:] {


### PR DESCRIPTION
This will allow a Middleware to alter the Response types instead of having to create a new one