### PR TITLE
Make MemorySessionDriver thread safe

### DIFF
--- a/Sources/Vapor/Server/SocketServer.swift
+++ b/Sources/Vapor/Server/SocketServer.swift
@@ -31,7 +31,7 @@ public class SocketServer: ServerDriver {
             while let socket = try? self.listenSocket.acceptClientSocket() {
                 
                 //wait for lock to notify a new connection
-                self.lock(self.clientSocketsLock) {
+                self.clientSocketsLock.locked {
                     //keep track of open sockets
                     self.clientSockets.insert(socket)
                 }
@@ -41,7 +41,7 @@ public class SocketServer: ServerDriver {
                     self.handleConnection(socket)
                     
                     //set lock to wait for another connection
-                    self.lock(self.clientSocketsLock) {
+                    self.clientSocketsLock.locked {
                         self.clientSockets.remove(socket)
                     }
                 })
@@ -62,7 +62,7 @@ public class SocketServer: ServerDriver {
         self.listenSocket.release()
         
         //shutdown all client sockets
-        self.lock(self.clientSocketsLock) {
+        self.clientSocketsLock.locked {
             for socket in self.clientSockets {
                 socket.shutdwn()
             }
@@ -109,21 +109,6 @@ public class SocketServer: ServerDriver {
             if !keepConnection { break }
         }
 
-    }
-    
-    
-
-    /**
-        Locking mechanism for holding thread until a 
-        new socket connection is ready.
-        
-        - parameter handle: NSLock
-        - parameter closure: Code that will run when the lock has been altered.
-    */
-    private func lock(handle: NSLock, closure: () -> ()) {
-        handle.lock()
-        closure()
-        handle.unlock();
     }
     
     /**

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -7,6 +7,7 @@ import Foundation
  */
 public class MemorySessionDriver: SessionDriver {
     var sessions = [String: [String: String]]()
+    private var sessionsLock = NSLock()
 
     public init() { }
 
@@ -16,7 +17,12 @@ public class MemorySessionDriver: SessionDriver {
             return nil
         }
 
-        return sessions[sessionIdentifier]?[key]
+        var value: String?
+        sessionsLock.locked {
+            value = sessions[sessionIdentifier]?[key]
+        }
+
+        return value
     }
 
     public func set(value: String?, forKey key: String, inSession session: Session) {
@@ -25,11 +31,13 @@ public class MemorySessionDriver: SessionDriver {
             return
         }
 
-        if sessions[sessionIdentifier] == nil {
-            sessions[sessionIdentifier] = [String: String]()
-        }
+        sessionsLock.locked {
+            if sessions[sessionIdentifier] == nil {
+                sessions[sessionIdentifier] = [String: String]()
+            }
 
-        sessions[sessionIdentifier]?[key] = value
+            sessions[sessionIdentifier]?[key] = value
+        }
     }
 
     public func newSessionIdentifier() -> String {
@@ -49,6 +57,8 @@ public class MemorySessionDriver: SessionDriver {
             return
         }
 
-        sessions[sessionIdentifier] = nil
+        sessionsLock.locked {
+            sessions[sessionIdentifier] = nil
+        }
     }
 }

--- a/Sources/Vapor/Utilities/NSLock+Closure.swift
+++ b/Sources/Vapor/Utilities/NSLock+Closure.swift
@@ -3,7 +3,6 @@
 //  Vapor
 //
 //  Created by James Richard on 3/2/16.
-//  Copyright © 2016 Tanner Nelson. All rights reserved.
 //
 
 import Foundation

--- a/Sources/Vapor/Utilities/NSLock+Closure.swift
+++ b/Sources/Vapor/Utilities/NSLock+Closure.swift
@@ -1,0 +1,17 @@
+//
+//  NSLock+Closure.swift
+//  Vapor
+//
+//  Created by James Richard on 3/2/16.
+//  Copyright © 2016 Tanner Nelson. All rights reserved.
+//
+
+import Foundation
+
+extension NSLock {
+    func locked(@noescape closure: () throws -> Void) rethrows {
+        lock()
+        defer { unlock() }
+        try closure()
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -6,6 +6,7 @@ XCTMain([
 	EnvironmentTests(),
 	HashTests(),
 	LogTests(),
+	MemorySessionDriverTests(),
 	ResponseTests(),
 	RouterTests(),
 	RouteTests()

--- a/Tests/Vapor/MemorySessionDriverTests.swift
+++ b/Tests/Vapor/MemorySessionDriverTests.swift
@@ -1,0 +1,126 @@
+//
+//  MemorySessionDriverTests.swift
+//  Vapor
+//
+//  Created by James Richard on 3/4/16.
+//
+
+import XCTest
+@testable import Vapor
+
+#if os(Linux)
+    extension MemorySessionDriverTests: XCTestCaseProvider {
+        var allTests : [(String, () throws -> Void)] {
+            return [
+                       ("testValueForKey_onSessionThatDoesntHaveIdentifier_isNil", testValueForKey_onSessionThatDoesntHaveIdentifier_isNil),
+                       ("testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil", testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil),
+                       ("testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil", testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil),
+                       ("testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue", testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue),
+                       ("testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions", testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions),
+                       ("testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly", testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly),
+                       ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly", testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly),
+                       ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue", testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue),
+                       ("testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions", testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions),
+                       ("testDestroySession_onSessionThatHasIdentifier_removesSession", testDestroySession_onSessionThatHasIdentifier_removesSession)
+            ]
+        }
+    }
+#endif
+
+class MemorySessionDriverTests: XCTestCase {
+    // MARK: - Obtaining Values
+    func testValueForKey_onSessionThatDoesntHaveIdentifier_isNil() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
+    }
+
+    func testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
+    }
+
+    func testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        subject.sessions = ["baz": [:]]
+        XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
+    }
+
+    func testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        subject.sessions = ["baz": ["foo":"bar"]]
+        XCTAssertEqual(subject.valueFor(key: "foo", inSession: session), "bar")
+    }
+
+    // MARK: - Setting Values
+    func testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        subject.set("foo", forKey: "bar", inSession: session)
+        XCTAssertTrue(subject.sessions.isEmpty)
+    }
+
+    func testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        subject.set("foo", forKey: "bar", inSession: session)
+        XCTAssertEqual(subject.sessions["baz"]?["bar"], "foo")
+    }
+
+    func testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        subject.sessions = ["baz":["bar":"foo"]]
+        subject.set("frob", forKey: "bar", inSession: session)
+        XCTAssertEqual(subject.sessions["baz"]?["bar"], "frob")
+    }
+
+    func testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        session.identifier = "baz"
+        subject.sessions = ["baz":["bar":"foo"]]
+        subject.set(nil, forKey: "bar", inSession: session)
+        XCTAssertNil(subject.sessions["baz"]?["bar"])
+    }
+
+    // MARK: - Destroying
+
+    func testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions() {
+        let subject = MemorySessionDriver()
+        let session = Session()
+        let sessions = ["baz":["bar":"foo"]]
+        subject.sessions = sessions
+        subject.destroy(session)
+
+        guard subject.sessions["baz"] != nil else {
+            XCTFail("Session was unexpectedly removed")
+            return
+        }
+
+        XCTAssertEqual(subject.sessions["baz"]!, ["bar":"foo"])
+    }
+
+    func testDestroySession_onSessionThatHasIdentifier_removesSession() {
+        let subject = MemorySessionDriver()
+        subject.sessions = ["baz":["bar":"foo"], "frob": [:]]
+        let session = Session()
+        session.identifier = "baz"
+        subject.destroy(session)
+
+        guard subject.sessions["frob"] != nil else {
+            XCTFail("Session was unexpectedly removed")
+            return
+        }
+
+        XCTAssertEqual(subject.sessions["frob"]!, [String: String]())
+    }
+}

--- a/XcodeProject/Vapor.xcodeproj/project.pbxproj
+++ b/XcodeProject/Vapor.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1A33BBAC1C874555000499CE /* NSLock+Closure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A33BBAB1C874555000499CE /* NSLock+Closure.swift */; };
 		1AC8BC7C1C84B5A500BAC14E /* MemorySessionDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */; };
 		3492B2EF1C787DD600D8E588 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EE1C787DD600D8E588 /* RouteTests.swift */; };
 		34CC59561C7BE3C9007CA680 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59551C7BE3C9007CA680 /* LogTests.swift */; };
@@ -84,6 +85,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1A33BBAB1C874555000499CE /* NSLock+Closure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSLock+Closure.swift"; path = "../../Sources/Vapor/Utilities/NSLock+Closure.swift"; sourceTree = "<group>"; };
 		1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemorySessionDriver.swift; path = ../Sources/Vapor/Session/MemorySessionDriver.swift; sourceTree = "<group>"; };
 		288CFC2D1C7AC01A00E4617A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Application.swift; path = ../Sources/Vapor/Core/Application.swift; sourceTree = SOURCE_ROOT; };
 		288CFC301C7AC02A00E4617A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Provider.swift; path = ../Sources/Vapor/Core/Provider.swift; sourceTree = SOURCE_ROOT; };
@@ -176,6 +178,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		1A33BBAA1C87453A000499CE /* Utilities */ = {
+			isa = PBXGroup;
+			children = (
+				1A33BBAB1C874555000499CE /* NSLock+Closure.swift */,
+			);
+			name = Utilities;
+			sourceTree = "<group>";
+		};
 		288CFC2F1C7AC02000E4617A /* Providers */ = {
 			isa = PBXGroup;
 			children = (
@@ -213,6 +223,7 @@
 				80202FFF1C77C94C009B8655 /* JSON */,
 				C304C8AF1C63051E00058C92 /* Fixes */,
 				800EFA541C822ECF00F6C066 /* Process */,
+				1A33BBAA1C87453A000499CE /* Utilities */,
 				3A91D3CE1C7F6AF900EA3CA0 /* Vapor.h */,
 				3A91D3D01C7F6AF900EA3CA0 /* Info.plist */,
 			);
@@ -628,6 +639,7 @@
 				3A91D3DE1C7F6B6600EA3CA0 /* LogDriver.swift in Sources */,
 				3A91D3E21C7F6B6600EA3CA0 /* Request.swift in Sources */,
 				3A91D3DF1C7F6B6600EA3CA0 /* Branch.swift in Sources */,
+				1A33BBAC1C874555000499CE /* NSLock+Closure.swift in Sources */,
 				3A91D3EE1C7F6B6600EA3CA0 /* SessionMiddleware.swift in Sources */,
 				3A91D3E71C7F6B6600EA3CA0 /* Socket.swift in Sources */,
 				3A91D3F71C7F6B6600EA3CA0 /* StringExtensions.swift in Sources */,

--- a/XcodeProject/Vapor.xcodeproj/project.pbxproj
+++ b/XcodeProject/Vapor.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		1A33BBAC1C874555000499CE /* NSLock+Closure.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A33BBAB1C874555000499CE /* NSLock+Closure.swift */; };
 		1AC8BC7C1C84B5A500BAC14E /* MemorySessionDriver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */; };
+		1AF2F51B1C89DE2A00A7B2EA /* MemorySessionDriverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AF2F51A1C89DE2A00A7B2EA /* MemorySessionDriverTests.swift */; };
 		3492B2EF1C787DD600D8E588 /* RouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3492B2EE1C787DD600D8E588 /* RouteTests.swift */; };
 		34CC59561C7BE3C9007CA680 /* LogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34CC59551C7BE3C9007CA680 /* LogTests.swift */; };
 		3A583A011C7FCA720044AAFF /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 3A583A001C7FCA720044AAFF /* libVapor.dylib */; };
@@ -87,6 +88,7 @@
 /* Begin PBXFileReference section */
 		1A33BBAB1C874555000499CE /* NSLock+Closure.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "NSLock+Closure.swift"; path = "../../Sources/Vapor/Utilities/NSLock+Closure.swift"; sourceTree = "<group>"; };
 		1AC8BC7B1C84B5A500BAC14E /* MemorySessionDriver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemorySessionDriver.swift; path = ../Sources/Vapor/Session/MemorySessionDriver.swift; sourceTree = "<group>"; };
+		1AF2F51A1C89DE2A00A7B2EA /* MemorySessionDriverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = MemorySessionDriverTests.swift; path = ../../Tests/Vapor/MemorySessionDriverTests.swift; sourceTree = "<group>"; };
 		288CFC2D1C7AC01A00E4617A /* Application.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Application.swift; path = ../Sources/Vapor/Core/Application.swift; sourceTree = SOURCE_ROOT; };
 		288CFC301C7AC02A00E4617A /* Provider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Provider.swift; path = ../Sources/Vapor/Core/Provider.swift; sourceTree = SOURCE_ROOT; };
 		3492B2EE1C787DD600D8E588 /* RouteTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouteTests.swift; path = ../Tests/Vapor/RouteTests.swift; sourceTree = SOURCE_ROOT; };
@@ -390,6 +392,7 @@
 				3492B2EE1C787DD600D8E588 /* RouteTests.swift */,
 				800EFA571C8231EE00F6C066 /* ProcessTests.swift */,
 				800EFA591C83A00300F6C066 /* QueryParametersTests.swift */,
+				1AF2F51A1C89DE2A00A7B2EA /* MemorySessionDriverTests.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -689,6 +692,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1AF2F51B1C89DE2A00A7B2EA /* MemorySessionDriverTests.swift in Sources */,
 				800EFA581C8231EE00F6C066 /* ProcessTests.swift in Sources */,
 				C38808641C62C0390067DADD /* ResponseTests.swift in Sources */,
 				800EFA5A1C83A00300F6C066 /* QueryParametersTests.swift in Sources */,


### PR DESCRIPTION
I also moved the handy lock with closure method from SocketServer into an extension. I wasn't sure where we'd put standard library extensions that weren't "fixes", so I made a new "Utilities" folder.