### PR TITLE
Changed String to Swift.String

### DIFF
--- a/Sources/Vapor/Response/ResponseConvertible.swift
+++ b/Sources/Vapor/Response/ResponseConvertible.swift
@@ -19,7 +19,7 @@ extension Response: ResponseConvertible {
     }
 }
 
-extension String: ResponseConvertible {
+extension Swift.String: ResponseConvertible {
 	public func response() -> Response {
 		return Response(status: .OK, html: self)
 	}


### PR DESCRIPTION
This works for me. Can someone confirm/explain why this change is needed?