### PR TITLE
Middleware refactor & remove Session shared state

### DIFF
--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -250,7 +250,7 @@ extension Application: ServerDriverDelegate {
 
 		// Loop through middlewares in order
 		for middleware in self.middleware {
-            handler = middleware.handle(forApplication: self, handler: handler)
+            handler = middleware.handle(handler, for: self)
 		}
 
 		do {

--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -27,7 +27,7 @@ public class Application {
         storing and reading values written to the
         users session.
     */
-    public var sessionDriver: SessionDriver
+    public var session: SessionDriver
 
 	/**
 		`Middleware` will be applied in the order
@@ -95,10 +95,10 @@ public class Application {
 	/**
 		Initialize the Application.
 	*/
-    public init(router: RouterDriver = BranchRouter(), server: ServerDriver = SocketServer(), sessionDriver: SessionDriver = MemorySessionDriver()) {
+    public init(router: RouterDriver = BranchRouter(), server: ServerDriver = SocketServer(), session: SessionDriver = MemorySessionDriver()) {
 		self.server = server
 		self.router = router
-        self.sessionDriver = sessionDriver
+        self.session = session
 
 		self.middleware = [
 			AbortMiddleware.self

--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -22,6 +22,13 @@ public class Application {
 	*/
 	public var server: ServerDriver
 
+    /**
+        The session driver is responsible for
+        storing and reading values written to the
+        users session.
+    */
+    public var sessionDriver: SessionDriver
+
 	/**
 		`Middleware` will be applied in the order
 		it is set in this array.
@@ -88,9 +95,10 @@ public class Application {
 	/**
 		Initialize the Application.
 	*/
-	public init(router: RouterDriver = BranchRouter(), server: ServerDriver = SocketServer()) {
+    public init(router: RouterDriver = BranchRouter(), server: ServerDriver = SocketServer(), sessionDriver: SessionDriver = MemorySessionDriver()) {
 		self.server = server
 		self.router = router
+        self.sessionDriver = sessionDriver
 
 		self.middleware = [
 			AbortMiddleware.self
@@ -242,7 +250,7 @@ extension Application: ServerDriverDelegate {
 
 		// Loop through middlewares in order
 		for middleware in self.middleware {
-			handler = middleware.handle(handler)
+            handler = middleware.handle(forApplication: self, handler: handler)
 		}
 
 		do {

--- a/Sources/Vapor/Middleware/AbortMiddleware.swift
+++ b/Sources/Vapor/Middleware/AbortMiddleware.swift
@@ -1,6 +1,6 @@
 public class AbortMiddleware: Middleware {
 
-    public class func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler {
+    public class func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
         return { request in
             do {
                 return try handler(request: request)

--- a/Sources/Vapor/Middleware/AbortMiddleware.swift
+++ b/Sources/Vapor/Middleware/AbortMiddleware.swift
@@ -1,6 +1,6 @@
 public class AbortMiddleware: Middleware {
 
-    public class func handle(handler: Request.Handler) -> Request.Handler {
+    public class func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler {
         return { request in
             do {
                 return try handler(request: request)

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -16,6 +16,6 @@ public protocol Middleware {
         Call `handler(request)` somewhere inside your custom
         handler to get the `Response` object.
     */
-    static func handle(handler: Request.Handler) -> Request.Handler
+    static func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler
     
 }

--- a/Sources/Vapor/Middleware/Middleware.swift
+++ b/Sources/Vapor/Middleware/Middleware.swift
@@ -16,6 +16,6 @@ public protocol Middleware {
         Call `handler(request)` somewhere inside your custom
         handler to get the `Response` object.
     */
-    static func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler
+    static func handle(handler: Request.Handler, for application: Application) -> Request.Handler
     
 }

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -44,7 +44,7 @@ public class Request {
     public var parameters: [String: String] = [:]
     
     ///Server stored information related from session cookie.
-    public let session = Session()
+    public internal(set) var session: Session?
     
     ///Requested hostname
     public let hostname: String

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -90,7 +90,7 @@ extension Application {
         
         //Apply any scoped middlewares
         for middleware in scopedMiddleware {
-            handler = middleware.handle(forApplication: self, handler: handler)
+            handler = middleware.handle(handler, for: self)
         }
         
         //Store the route for registering with Router later

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -90,7 +90,7 @@ extension Application {
         
         //Apply any scoped middlewares
         for middleware in scopedMiddleware {
-            handler = middleware.handle(handler)
+            handler = middleware.handle(forApplication: self, handler: handler)
         }
         
         //Store the route for registering with Router later

--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -12,31 +12,21 @@ public class MemorySessionDriver: SessionDriver {
     public init() { }
     
     public func valueFor(key key: String, inSession session: Session) -> String? {
-        guard let sessionIdentifier = session.identifier else {
-            Log.warning("Unable to read a value for '\(key)': The session has not been registered yet")
-            return nil
-        }
-        
         var value: String?
         sessionsLock.locked {
-            value = sessions[sessionIdentifier]?[key]
+            value = sessions[session.identifier]?[key]
         }
         
         return value
     }
     
     public func set(value: String?, forKey key: String, inSession session: Session) {
-        guard let sessionIdentifier = session.identifier else {
-            Log.warning("Unable to store a value for '\(key)': The session has not been registered yet")
-            return
-        }
-        
         sessionsLock.locked {
-            if sessions[sessionIdentifier] == nil {
-                sessions[sessionIdentifier] = [String: String]()
+            if sessions[session.identifier] == nil {
+                sessions[session.identifier] = [String: String]()
             }
             
-            sessions[sessionIdentifier]?[key] = value
+            sessions[session.identifier]?[key] = value
         }
     }
     
@@ -52,13 +42,8 @@ public class MemorySessionDriver: SessionDriver {
     }
     
     public func destroy(session: Session) {
-        guard let sessionIdentifier = session.identifier else {
-            Log.warning("Unable to destroy the session: The session has not been registered yet")
-            return
-        }
-        
         sessionsLock.locked {
-            sessions[sessionIdentifier] = nil
+            sessions[session.identifier] = nil
         }
     }
 }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -1,25 +1,24 @@
 
 public class Session {
 
-    public static var driver: SessionDriver = MemorySessionDriver()
-
     public internal(set) var identifier: String?
+    var driver: SessionDriver?
 
 	init() {
 		//do nothing
 	}
 
 	public func destroy() {
-        Session.driver.destroy(self)
+        driver?.destroy(self)
 	}
 
     public subscript(key: String) -> String? {
         get {
-            return Session.driver.valueFor(key: key, inSession: self)
+            return driver?.valueFor(key: key, inSession: self)
         }
 
         set {
-            Session.driver.set(newValue, forKey: key, inSession: self)
+            driver?.set(newValue, forKey: key, inSession: self)
         }
     }
 }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -1,24 +1,25 @@
 
 public class Session {
 
-    public internal(set) var identifier: String?
-    var driver: SessionDriver?
+    public let identifier: String
+    var driver: SessionDriver
 
-	init() {
-		//do nothing
+    init(identifier: String, driver: SessionDriver) {
+        self.identifier = identifier
+        self.driver = driver
 	}
 
 	public func destroy() {
-        driver?.destroy(self)
+        driver.destroy(self)
 	}
 
     public subscript(key: String) -> String? {
         get {
-            return driver?.valueFor(key: key, inSession: self)
+            return driver.valueFor(key: key, inSession: self)
         }
 
         set {
-            driver?.set(newValue, forKey: key, inSession: self)
+            driver.set(newValue, forKey: key, inSession: self)
         }
     }
 }

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -2,8 +2,8 @@ class SessionMiddleware: Middleware {
 
     static func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
         return { request in
-            let sessionIdentifier = request.cookies["vapor-session"] ?? application.sessionDriver.makeSessionIdentifier()
-            request.session = Session(identifier: sessionIdentifier, driver: application.sessionDriver)
+            let sessionIdentifier = request.cookies["vapor-session"] ?? application.session.makeSessionIdentifier()
+            request.session = Session(identifier: sessionIdentifier, driver: application.session)
 
             let response = try handler(request: request)
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -2,8 +2,9 @@ class SessionMiddleware: Middleware {
 
     static func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler {
         return { request in
-            let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.makeSessionIdentifier()
+            let sessionIdentifier = request.cookies["vapor-session"] ?? application.sessionDriver.makeSessionIdentifier()
             request.session.identifier = sessionIdentifier
+            request.session.driver = application.sessionDriver
 
             let response = try handler(request: request)
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -1,6 +1,6 @@
 class SessionMiddleware: Middleware {
 
-    static func handle(handler: Request.Handler) -> Request.Handler {
+    static func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler {
         return { request in
             let sessionIdentifier = request.cookies["vapor-session"] ?? Session.driver.makeSessionIdentifier()
             request.session.identifier = sessionIdentifier

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -3,8 +3,7 @@ class SessionMiddleware: Middleware {
     static func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
         return { request in
             let sessionIdentifier = request.cookies["vapor-session"] ?? application.sessionDriver.makeSessionIdentifier()
-            request.session.identifier = sessionIdentifier
-            request.session.driver = application.sessionDriver
+            request.session = Session(identifier: sessionIdentifier, driver: application.sessionDriver)
 
             let response = try handler(request: request)
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -1,6 +1,6 @@
 class SessionMiddleware: Middleware {
 
-    static func handle(forApplication application: Application, handler: Request.Handler) -> Request.Handler {
+    static func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
         return { request in
             let sessionIdentifier = request.cookies["vapor-session"] ?? application.sessionDriver.makeSessionIdentifier()
             request.session.identifier = sessionIdentifier

--- a/Tests/Vapor/MemorySessionDriverTests.swift
+++ b/Tests/Vapor/MemorySessionDriverTests.swift
@@ -12,13 +12,13 @@ import XCTest
     extension MemorySessionDriverTests: XCTestCaseProvider {
         var allTests : [(String, () throws -> Void)] {
             return [
-                       ("testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil", testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil),
-                       ("testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil", testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil),
-                       ("testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue", testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue),
-                       ("testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly", testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly),
-                       ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly", testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly),
-                       ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue", testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue),
-                       ("testDestroySession_onSessionThatHasIdentifier_removesSession", testDestroySession_onSessionThatHasIdentifier_removesSession)
+                       ("testValueForKey_onNonExistantSession_isNil", testValueForKey_onNonExistantSession_isNil),
+                       ("testValueForKey_onExistingSession_onNonExistingKey_isNil", testValueForKey_onExistingSession_onNonExistingKey_isNil),
+                       ("testValueForKey_onExistingSession_onExistingKey_isKeyValue", testValueForKey_onExistingSession_onExistingKey_isKeyValue),
+                       ("testSetValueForKey_setsValueCorrectly", testSetValueForKey_setsValueCorrectly),
+                       ("testSetValueForKey_withExistingValue_overwritesValueCorrectly", testSetValueForKey_withExistingValue_overwritesValueCorrectly),
+                       ("testSetValueForKey_withExistingValue_toNilErasesValue", testSetValueForKey_withExistingValue_toNilErasesValue),
+                       ("testDestroySession_removesSession", testDestroySession_removesSession)
             ]
         }
     }

--- a/Tests/Vapor/MemorySessionDriverTests.swift
+++ b/Tests/Vapor/MemorySessionDriverTests.swift
@@ -12,15 +12,12 @@ import XCTest
     extension MemorySessionDriverTests: XCTestCaseProvider {
         var allTests : [(String, () throws -> Void)] {
             return [
-                       ("testValueForKey_onSessionThatDoesntHaveIdentifier_isNil", testValueForKey_onSessionThatDoesntHaveIdentifier_isNil),
                        ("testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil", testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil),
                        ("testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil", testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil),
                        ("testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue", testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue),
-                       ("testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions", testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions),
                        ("testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly", testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly),
                        ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly", testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly),
                        ("testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue", testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue),
-                       ("testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions", testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions),
                        ("testDestroySession_onSessionThatHasIdentifier_removesSession", testDestroySession_onSessionThatHasIdentifier_removesSession)
             ]
         }
@@ -29,64 +26,45 @@ import XCTest
 
 class MemorySessionDriverTests: XCTestCase {
     // MARK: - Obtaining Values
-    func testValueForKey_onSessionThatDoesntHaveIdentifier_isNil() {
+    func testValueForKey_onNonExistantSession_isNil() {
         let subject = MemorySessionDriver()
-        let session = Session()
+        let session = Session(identifier: "baz", driver: subject)
         XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
     }
 
-    func testValueForKey_onSessionWithIdentifier_onNonExistantSession_isNil() {
+    func testValueForKey_onExistingSession_onNonExistingKey_isNil() {
         let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
-        XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
-    }
-
-    func testValueForKey_onSessionWithIdentifier_onExistingSession_onNonExistingKey_isNil() {
-        let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.sessions = ["baz": [:]]
         XCTAssertNil(subject.valueFor(key: "foo", inSession: session))
     }
 
-    func testValueForKey_onSessionWithIdentifier_onExistingSession_onExistingKey_isKeyValue() {
+    func testValueForKey_onExistingSession_onExistingKey_isKeyValue() {
         let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.sessions = ["baz": ["foo":"bar"]]
         XCTAssertEqual(subject.valueFor(key: "foo", inSession: session), "bar")
     }
 
     // MARK: - Setting Values
-    func testSetValueForKey_onSessionThatDoesntHaveIdentifier_doesntAlterSessions() {
+    func testSetValueForKey_setsValueCorrectly() {
         let subject = MemorySessionDriver()
-        let session = Session()
-        subject.set("foo", forKey: "bar", inSession: session)
-        XCTAssertTrue(subject.sessions.isEmpty)
-    }
-
-    func testSetValueForKey_onSessionWithIdentifier_setsValueCorrectly() {
-        let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.set("foo", forKey: "bar", inSession: session)
         XCTAssertEqual(subject.sessions["baz"]?["bar"], "foo")
     }
 
-    func testSetValueForKey_onSessionWithIdentifier_withExistingValue_overwritesValueCorrectly() {
+    func testSetValueForKey_withExistingValue_overwritesValueCorrectly() {
         let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.sessions = ["baz":["bar":"foo"]]
         subject.set("frob", forKey: "bar", inSession: session)
         XCTAssertEqual(subject.sessions["baz"]?["bar"], "frob")
     }
 
-    func testSetValueForKey_onSessionWithIdentifier_withExistingValue_toNilErasesValue() {
+    func testSetValueForKey_withExistingValue_toNilErasesValue() {
         let subject = MemorySessionDriver()
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.sessions = ["baz":["bar":"foo"]]
         subject.set(nil, forKey: "bar", inSession: session)
         XCTAssertNil(subject.sessions["baz"]?["bar"])
@@ -94,26 +72,10 @@ class MemorySessionDriverTests: XCTestCase {
 
     // MARK: - Destroying
 
-    func testDestroySession_onSessionThatDoesntHaveIdentifier_doesntAlterSessions() {
-        let subject = MemorySessionDriver()
-        let session = Session()
-        let sessions = ["baz":["bar":"foo"]]
-        subject.sessions = sessions
-        subject.destroy(session)
-
-        guard subject.sessions["baz"] != nil else {
-            XCTFail("Session was unexpectedly removed")
-            return
-        }
-
-        XCTAssertEqual(subject.sessions["baz"]!, ["bar":"foo"])
-    }
-
-    func testDestroySession_onSessionThatHasIdentifier_removesSession() {
+    func testDestroySession_removesSession() {
         let subject = MemorySessionDriver()
         subject.sessions = ["baz":["bar":"foo"], "frob": [:]]
-        let session = Session()
-        session.identifier = "baz"
+        let session = Session(identifier: "baz", driver: subject)
         subject.destroy(session)
 
         guard subject.sessions["frob"] != nil else {

--- a/Tests/Vapor/RouteTests.swift
+++ b/Tests/Vapor/RouteTests.swift
@@ -108,7 +108,7 @@ class RouteTests: XCTestCase {
         }
         
         for middleware in app.middleware {
-            handler = middleware.handle(forApplication: app, handler: handler)
+            handler = middleware.handle(handler, for: app)
         }
         
         do {

--- a/Tests/Vapor/RouteTests.swift
+++ b/Tests/Vapor/RouteTests.swift
@@ -108,7 +108,7 @@ class RouteTests: XCTestCase {
         }
         
         for middleware in app.middleware {
-            handler = middleware.handle(handler)
+            handler = middleware.handle(forApplication: app, handler: handler)
         }
         
         do {

--- a/Tests/Vapor/SessionTests.swift
+++ b/Tests/Vapor/SessionTests.swift
@@ -23,9 +23,8 @@ import XCTest
 
 class SessionTests: XCTestCase {
     func testDestroy_asksDriverToDestroy() {
-        let subject = Session()
         let driver = TestDriver()
-        subject.driver = driver
+        let subject = Session(identifier: "baz", driver: driver)
         subject.destroy()
         XCTAssertEqual(driver.actions.count, 1)
         guard !driver.actions.isEmpty else { return }
@@ -38,9 +37,8 @@ class SessionTests: XCTestCase {
     }
 
     func testSubscriptGet_asksDriverForValue() {
-        let subject = Session()
         let driver = TestDriver()
-        subject.driver = driver
+        let subject = Session(identifier: "baz", driver: driver)
         _ = subject["test"]
 
         XCTAssertEqual(driver.actions.count, 1)
@@ -55,9 +53,8 @@ class SessionTests: XCTestCase {
     }
 
     func testSubscriptSet_asksDriverToSetValue() {
-        let subject = Session()
         let driver = TestDriver()
-        subject.driver = driver
+        let subject = Session(identifier: "baz", driver: driver)
         subject["foo"] = "bar"
 
         XCTAssertEqual(driver.actions.count, 1)

--- a/Tests/Vapor/SessionTests.swift
+++ b/Tests/Vapor/SessionTests.swift
@@ -22,30 +22,14 @@ import XCTest
 #endif
 
 class SessionTests: XCTestCase {
-    var originalDriver: SessionDriver!
-    private var testDriver: TestDriver!
-
-    // TODO: When XCTestCase is converted from a protocol to a class on Linux, these should be renamed to setUp() and 
-    // tearDown(), and not called manually.
-    func doSetUp() {
-        originalDriver = Session.driver
-        testDriver = TestDriver()
-        Session.driver = testDriver
-    }
-    
-    func doTearDown() {
-        Session.driver = originalDriver
-        testDriver = nil
-    }
-    
     func testDestroy_asksDriverToDestroy() {
-        doSetUp()
-        defer { doTearDown() }
         let subject = Session()
+        let driver = TestDriver()
+        subject.driver = driver
         subject.destroy()
-        XCTAssertEqual(testDriver.actions.count, 1)
-        guard !testDriver.actions.isEmpty else { return }
-        guard case .Destroy(let session) = testDriver.actions[0] else {
+        XCTAssertEqual(driver.actions.count, 1)
+        guard !driver.actions.isEmpty else { return }
+        guard case .Destroy(let session) = driver.actions[0] else {
             XCTFail("Recorded action was not a destroy action")
             return
         }
@@ -54,14 +38,14 @@ class SessionTests: XCTestCase {
     }
 
     func testSubscriptGet_asksDriverForValue() {
-        doSetUp()
-        defer { doTearDown() }
         let subject = Session()
+        let driver = TestDriver()
+        subject.driver = driver
         _ = subject["test"]
 
-        XCTAssertEqual(testDriver.actions.count, 1)
-        guard !testDriver.actions.isEmpty else { return }
-        guard case .ValueFor(let key, let session) = testDriver.actions[0] else {
+        XCTAssertEqual(driver.actions.count, 1)
+        guard !driver.actions.isEmpty else { return }
+        guard case .ValueFor(let key, let session) = driver.actions[0] else {
             XCTFail("Recorded action was not a value for action")
             return
         }
@@ -71,14 +55,14 @@ class SessionTests: XCTestCase {
     }
 
     func testSubscriptSet_asksDriverToSetValue() {
-        doSetUp()
-        defer { doTearDown() }
         let subject = Session()
+        let driver = TestDriver()
+        subject.driver = driver
         subject["foo"] = "bar"
 
-        XCTAssertEqual(testDriver.actions.count, 1)
-        guard !testDriver.actions.isEmpty else { return }
-        guard case .SetValue(let value, let key, let session) = testDriver.actions[0] else {
+        XCTAssertEqual(driver.actions.count, 1)
+        guard !driver.actions.isEmpty else { return }
+        guard case .SetValue(let value, let key, let session) = driver.actions[0] else {
             XCTFail("Recorded action was not a set value action")
             return
         }

--- a/Tests/Vapor/SessionTests.swift
+++ b/Tests/Vapor/SessionTests.swift
@@ -26,10 +26,8 @@ class SessionTests: XCTestCase {
         let driver = TestDriver()
         let subject = Session(identifier: "baz", driver: driver)
         subject.destroy()
-        XCTAssertEqual(driver.actions.count, 1)
-        guard !driver.actions.isEmpty else { return }
-        guard case .Destroy(let session) = driver.actions[0] else {
-            XCTFail("Recorded action was not a destroy action")
+        guard let action = driver.actions.first, case .Destroy(let session) = action else {
+            XCTFail("No actions recorded or recorded action was not a destroy action")
             return
         }
 
@@ -41,10 +39,8 @@ class SessionTests: XCTestCase {
         let subject = Session(identifier: "baz", driver: driver)
         _ = subject["test"]
 
-        XCTAssertEqual(driver.actions.count, 1)
-        guard !driver.actions.isEmpty else { return }
-        guard case .ValueFor(let key, let session) = driver.actions[0] else {
-            XCTFail("Recorded action was not a value for action")
+        guard let action = driver.actions.first, case .ValueFor(let key, let session) = action else {
+            XCTFail("No actions recorded or recorded action was not a value for action")
             return
         }
 
@@ -57,10 +53,8 @@ class SessionTests: XCTestCase {
         let subject = Session(identifier: "baz", driver: driver)
         subject["foo"] = "bar"
 
-        XCTAssertEqual(driver.actions.count, 1)
-        guard !driver.actions.isEmpty else { return }
-        guard case .SetValue(let value, let key, let session) = driver.actions[0] else {
-            XCTFail("Recorded action was not a set value action")
+        guard let action = driver.actions.first, case .SetValue(let value, let key, let session) = action else {
+            XCTFail("No actions recorded or recorded action was not a set value action")
             return
         }
 


### PR DESCRIPTION
@tannernelson This includes `Application` in the `Middleware` `handle` method, allowing the `SessionMiddleware` to operate on application-level data and configure the session there, instead of it being a shared class variable, as we discussed.

The spacing in the diff seems a bit off; It looks right in Xcode. Not sure what to do about that =\