### PR TITLE
Formalize IP Override

### DIFF
--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -86,6 +86,7 @@ public class Application {
     var scopedPrefix: String?
 
 	var port: Int = 80
+	var ip: String = "0.0.0.0"
 
 	var routes: [Route] = []
 
@@ -158,28 +159,35 @@ public class Application {
 			self.dynamicType.workDir = workDir
 		}
 
-		if let portString = Process.valueFor(argument: "port"), let portInt = Int(portString) {
-			Log.info("Port override: \(portInt)")
-			self.port = portInt
+		if let ip = Process.valueFor(argument: "ip") {
+			Log.info("IP override: \(ip)")
+			self.ip = ip
+		}
+
+		if let port = Process.valueFor(argument: "port")?.int {
+			Log.info("Port override: \(port)")
+			self.port = port
 		}
 	}
 
 	/**
 		Boots the chosen server driver and
-		runs on the supplied port.
+		optionally runs on the supplied
+		ip & port overrides
 	*/
-	public func start(port port: Int = 80) {
+	public func start(ip ip: String? = nil, port: Int? = nil) {
 		self.bootProviders()
 		self.server.delegate = self
 
-		self.port = port
+		self.ip = ip ?? self.ip
+		self.port = port ?? self.port
 
 		self.bootRoutes()
 		self.bootArguments()
 
 		do {
-			try self.server.boot(port: self.port)
-			Log.info("Server has started on port \(self.port)")
+			try self.server.boot(ip: self.ip, port: self.port)
+			Log.info("Server has started on \(self.ip):\(self.port)")
 			self.loop()
 		} catch {
 			Log.info("Server start error: \(error)")

--- a/Sources/Vapor/Server/ServerDriver.swift
+++ b/Sources/Vapor/Server/ServerDriver.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public protocol ServerDriver {
-    func boot(port port: Int) throws
+    func boot(ip ip: String, port: Int) throws
     func halt()
-    
+
     var delegate: ServerDriverDelegate? { get set }
 }
 

--- a/Sources/Vapor/Server/Socket.swift
+++ b/Sources/Vapor/Server/Socket.swift
@@ -45,8 +45,8 @@ public enum SocketError: ErrorType {
 
 public class Socket: Hashable, Equatable {
 
-    public class func tcpSocketForListen(port: in_port_t, maxPendingConnection: Int32 = SOMAXCONN) throws -> Socket {
-        
+    public class func tcpSocketForListen(ip: String, port: in_port_t, maxPendingConnection: Int32 = SOMAXCONN) throws -> Socket {
+
         #if os(Linux)
             let socketFileDescriptor = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         #else
@@ -72,8 +72,7 @@ public class Socket: Hashable, Equatable {
         #endif
         addr.sin_family = sa_family_t(AF_INET)
         addr.sin_port = Socket.htonsPort(port)
-        
-        let ip = Process.valueFor(argument: "ip") ?? "0.0.0.0"
+
         addr.sin_addr = in_addr(s_addr: inet_addr(ip))
         addr.sin_zero = (0, 0, 0, 0, 0, 0, 0, 0)
         

--- a/Sources/Vapor/Server/SocketServer.swift
+++ b/Sources/Vapor/Server/SocketServer.swift
@@ -15,13 +15,13 @@ public class SocketServer: ServerDriver {
      
         - parameter port: The port to listen on.
      */
-    public func boot(port port: Int) throws {
+    public func boot(ip ip: String, port: Int) throws {
         //stop the server if it's running
         self.halt()
         
         //open a socket, might fail
-        self.listenSocket = try Socket.tcpSocketForListen(UInt16(port))
-        
+        self.listenSocket = try Socket.tcpSocketForListen(ip, port: UInt16(port))
+
         dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_BACKGROUND, 0)) {
             
             //creates the infinite loop that will wait for client connections


### PR DESCRIPTION
The `--ip=` cli option was previously hacked into `Server/Socket.swift`, but now that we're expanding with different server drivers, rather than continuing to have each driver implement on it’s own (see: https://github.com/qutheory/vapor-curassow-server/pull/1), I think it's time to formalize the option.

I've added it throughout Application, ServerDriver and the existing SocketServer.