### PR TITLE
session fixes

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -55,7 +55,12 @@ public class Request {
         return false
     }
 
-    public init(method: Method, path: String, address: String?, headers: [String: String], body: [UInt8]) {
+    public init(method: Method, path: String, address: String?, headers caseSensitiveHeaders: [String: String], body: [UInt8]) {
+        var headers: [String: String] = [:]
+        for (key, val) in caseSensitiveHeaders {
+            headers[key.lowercaseString] = val
+        }
+        
         self.method = method
         self.path = path.split(separator: "?").first ?? ""
         self.address = address

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -42,7 +42,7 @@ public class Request {
     public var parameters: [String: String] = [:]
     
     ///Server stored information related from session cookie.
-    public internal(set) var session: Session?
+    public var session: Session?
     
     ///Requested hostname
     public let hostname: String
@@ -85,7 +85,7 @@ public class Request {
     */
     class func parseCookies(string: String?) -> [String: String] {
         var cookies: [String: String] = [:]
-        
+
         guard let string = string else {
             return cookies
         }
@@ -99,7 +99,7 @@ public class Request {
                 cookies[key] = cookieArray[1]
             }
         }
-        
+
         return cookies
     }
     

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -55,19 +55,14 @@ public class Request {
         return false
     }
 
-    public init(method: Method, path: String, address: String?, headers caseSensitiveHeaders: [String: String], body: [UInt8]) {
-        var headers: [String: String] = [:]
-        for (key, val) in caseSensitiveHeaders {
-            headers[key.lowercaseString] = val
-        }
-        
+    public init(method: Method, path: String, address: String?, headers: [String: String], body: [UInt8]) {
         self.method = method
         self.path = path.split(separator: "?").first ?? ""
         self.address = address
         self.headers = headers
         self.body = body
-        self.cookies = Request.parseCookies(headers["cookie"])
-        self.hostname = headers["host"] ?? "*"
+        self.cookies = Request.parseCookies(headers["Cookie"])
+        self.hostname = headers["Host"] ?? "*"
         
         let query = path.queryData()
         self.data = Data(query: query, bytes: body)

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -80,6 +80,12 @@ extension Application {
         add(method, path: path, makeControllerWith: Controller.init, action: action)
     }
     
+    public final func add<Controller: ApplicationInitializable>(method: Request.Method, path: String, action: Controller -> Route.Handler) {
+        add(method, path: path, makeControllerWith: {
+            return Controller(application: self)
+        }, action: action)
+    }
+    
     public final func add(method: Request.Method, path: String, handler: Route.Handler) {
         
         //Convert Route.Handler to Request.Handler

--- a/Sources/Vapor/Routing/ApplicationInitializable.swift
+++ b/Sources/Vapor/Routing/ApplicationInitializable.swift
@@ -1,0 +1,3 @@
+public protocol ApplicationInitializable {
+    init(application: Application)
+}

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -6,7 +6,7 @@
  */
 public protocol ResourceController {
     /// Display many instances
-	  func index(request: Request) throws -> ResponseConvertible
+    func index(request: Request) throws -> ResponseConvertible
 
     /// Create a new instance.
     func store(request: Request) throws -> ResponseConvertible

--- a/Sources/Vapor/Server/RequestHeader.swift
+++ b/Sources/Vapor/Server/RequestHeader.swift
@@ -38,7 +38,7 @@ extension Request {
             // Drop first to remove leading ` ` key is actually `: `, but doesn't support splitting on substring, only char
             guard let key = components.first, let val = components.last?.characters.dropFirst() else { throw Error.InvalidHeaderKeyPair }
             
-            return (key.lowercaseString, String(val))
+            return (key, String(val))
         }
     }
 }

--- a/Sources/Vapor/Server/RequestHeader.swift
+++ b/Sources/Vapor/Server/RequestHeader.swift
@@ -38,7 +38,7 @@ extension Request {
             // Drop first to remove leading ` ` key is actually `: `, but doesn't support splitting on substring, only char
             guard let key = components.first, let val = components.last?.characters.dropFirst() else { throw Error.InvalidHeaderKeyPair }
             
-            return (key, String(val))
+            return (key.lowercaseString, String(val))
         }
     }
 }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -3,15 +3,18 @@ public class Session {
 
     public let identifier: String
     var driver: SessionDriver
+    public var enabled: Bool
 
     public init(driver: SessionDriver) {
-        self.identifier = driver.makeSessionIdentifier()
         self.driver = driver
+        identifier = driver.makeSessionIdentifier()
+        enabled = false
     }
 
     init(identifier: String, driver: SessionDriver) {
-        self.identifier = identifier
         self.driver = driver
+        self.identifier = identifier
+        enabled = true
 	}
 
 	public func destroy() {
@@ -22,8 +25,8 @@ public class Session {
         get {
             return driver.valueFor(key: key, inSession: self)
         }
-
         set {
+            enabled = true
             driver.set(newValue, forKey: key, inSession: self)
         }
     }

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -18,6 +18,7 @@ public class Session {
 	}
 
 	public func destroy() {
+        enabled = false
         driver.destroy(self)
 	}
 

--- a/Sources/Vapor/Session/Session.swift
+++ b/Sources/Vapor/Session/Session.swift
@@ -4,6 +4,11 @@ public class Session {
     public let identifier: String
     var driver: SessionDriver
 
+    public init(driver: SessionDriver) {
+        self.identifier = driver.makeSessionIdentifier()
+        self.driver = driver
+    }
+
     init(identifier: String, driver: SessionDriver) {
         self.identifier = identifier
         self.driver = driver

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -1,14 +1,16 @@
 class SessionMiddleware: Middleware {
 
-    static func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
+    static func handle(handler: Request.Handler, for app: Application) -> Request.Handler {
         return { request in
             if let sessionIdentifier = request.cookies["vapor-session"] {
-            	request.session = Session(identifier: sessionIdentifier, driver: application.session)
+            	request.session = Session(identifier: sessionIdentifier, driver: app.session)
+            } else {
+                request.session = Session(driver: app.session)
             }
 
             let response = try handler(request: request)
 
-            if let session = request.session {
+            if let session = request.session where session.enabled {
             	response.cookies["vapor-session"] = session.identifier
             }
 

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -2,12 +2,15 @@ class SessionMiddleware: Middleware {
 
     static func handle(handler: Request.Handler, for application: Application) -> Request.Handler {
         return { request in
-            let sessionIdentifier = request.cookies["vapor-session"] ?? application.session.makeSessionIdentifier()
-            request.session = Session(identifier: sessionIdentifier, driver: application.session)
+            if let sessionIdentifier = request.cookies["vapor-session"] {
+            	request.session = Session(identifier: sessionIdentifier, driver: application.session)
+            }
 
             let response = try handler(request: request)
 
-            response.cookies["vapor-session"] = sessionIdentifier
+            if let session = request.session {
+            	response.cookies["vapor-session"] = session.identifier
+            }
 
             return response
         }

--- a/Sources/VaporDev/main.swift
+++ b/Sources/VaporDev/main.swift
@@ -30,14 +30,7 @@ app.get(i, s) { request, int, string in
 }
 
 app.get("session") { request in 
-    if request.session == nil {
-        //create a new session
-        let session = Session(driver: app.session)
-        session["name"] = "Vapor"
-
-        request.session = session
-    }
-    
+    request.session?["name"] = "Vapor"
     return "Session set"
 }
 

--- a/Sources/VaporDev/main.swift
+++ b/Sources/VaporDev/main.swift
@@ -29,6 +29,16 @@ app.get(i, s) { request, int, string in
     ])
 }
 
+app.get("session") { request in 
+    if request.session == nil {
+        //create a new session
+        request.session = Session(driver: app.session)
+        request.session?["name"] = "Vapor"
+    }
+    
+    return "Session set"
+}
+
 app.post("json") { request in
     //parse a key inside the received json
     guard let count = request.data["unicorns"]?.int else {

--- a/Sources/VaporDev/main.swift
+++ b/Sources/VaporDev/main.swift
@@ -32,8 +32,10 @@ app.get(i, s) { request, int, string in
 app.get("session") { request in 
     if request.session == nil {
         //create a new session
-        request.session = Session(driver: app.session)
-        request.session?["name"] = "Vapor"
+        let session = Session(driver: app.session)
+        session["name"] = "Vapor"
+
+        request.session = session
     }
     
     return "Session set"

--- a/Tests/Vapor/RouterTests.swift
+++ b/Tests/Vapor/RouterTests.swift
@@ -38,7 +38,7 @@ class RouterTests: XCTestCase {
             method: .Get,
             path: "test",
             address: nil,
-            headers: ["host": "other.test"],
+            headers: ["Host": "other.test"],
             body: []
         )
         
@@ -70,8 +70,8 @@ class RouterTests: XCTestCase {
         }
         router.register(route_2)
         
-        let request_1 = Request(method: .Get, path: "test", address: nil, headers: ["host": "other.test"], body: [])
-        let request_2 = Request(method: .Get, path: "test", address: nil, headers: ["host": "vapor.test"], body: [])
+        let request_1 = Request(method: .Get, path: "test", address: nil, headers: ["Host": "other.test"], body: [])
+        let request_2 = Request(method: .Get, path: "test", address: nil, headers: ["Host": "vapor.test"], body: [])
         
         let handler_1 = router.route(request_1)
         let handler_2 = router.route(request_2)

--- a/XcodeProject/Vapor.xcodeproj/project.pbxproj
+++ b/XcodeProject/Vapor.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		C387A0431C95FEBA00B6282E /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = C387A0361C95FDFE00B6282E /* main.swift */; };
 		C38808641C62C0390067DADD /* ResponseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C38808631C62C0390067DADD /* ResponseTests.swift */; };
 		C3943DC31C7663E80014F4EE /* RouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3943DC21C7663E80014F4EE /* RouterTests.swift */; };
+		C3B4F38E1C9F5D9E00CB2731 /* ApplicationInitializable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3B4F38D1C9F5D9E00CB2731 /* ApplicationInitializable.swift */; };
 		C3DFB55D1C80C2860045801C /* MyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DFB5541C80C2860045801C /* MyController.swift */; };
 		C3F683361C7D1EF300033AA2 /* ControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3F683351C7D1EF300033AA2 /* ControllerTests.swift */; };
 /* End PBXBuildFile section */
@@ -185,6 +186,7 @@
 		C387A03B1C95FE1300B6282E /* Generator */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = Generator; sourceTree = BUILT_PRODUCTS_DIR; };
 		C38808631C62C0390067DADD /* ResponseTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ResponseTests.swift; path = ../Tests/Vapor/ResponseTests.swift; sourceTree = SOURCE_ROOT; };
 		C3943DC21C7663E80014F4EE /* RouterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RouterTests.swift; path = ../Tests/Vapor/RouterTests.swift; sourceTree = SOURCE_ROOT; };
+		C3B4F38D1C9F5D9E00CB2731 /* ApplicationInitializable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ApplicationInitializable.swift; sourceTree = "<group>"; };
 		C3DFB5541C80C2860045801C /* MyController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MyController.swift; sourceTree = "<group>"; };
 		C3DFB5571C80C2860045801C /* vapor-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "vapor-logo.png"; sourceTree = "<group>"; };
 		C3DFB5591C80C2860045801C /* app.css */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.css; path = app.css; sourceTree = "<group>"; };
@@ -395,6 +397,7 @@
 			children = (
 				C31A82941C9F4AB8005F1DBE /* Application+Route.swift */,
 				C31A82951C9F4AB8005F1DBE /* DefaultInitializable.swift */,
+				C3B4F38D1C9F5D9E00CB2731 /* ApplicationInitializable.swift */,
 				C31A82961C9F4AB8005F1DBE /* ResourceController.swift */,
 				C31A82971C9F4AB8005F1DBE /* Route.swift */,
 			);
@@ -775,6 +778,7 @@
 				C31A82DB1C9F4AB8005F1DBE /* RenderDriver.swift in Sources */,
 				C31A82BD1C9F4AB8005F1DBE /* LogDriver.swift in Sources */,
 				C31A82D51C9F4AB8005F1DBE /* SessionMiddleware.swift in Sources */,
+				C3B4F38E1C9F5D9E00CB2731 /* ApplicationInitializable.swift in Sources */,
 				C31A82D91C9F4AB8005F1DBE /* S4.swift in Sources */,
 				C31A82B11C9F4AB8005F1DBE /* Generated.swift in Sources */,
 				C31A82C31C9F4AB8005F1DBE /* Response.swift in Sources */,


### PR DESCRIPTION
This makes some updates to Session so that we don't create them unnecessarily.

If you want to start a new session, you do so explicitly like 

```swift
if request.session == nil {
    //create a new session
    let session = Session(driver: app.session)
    session["name"] = "Vapor"

    request.session = session
}
```

We could create some sort of helper method on `app` to create sessions so that you don't have to remember to pass the `app.session` driver.

```swift
app.makeSession()
```

It also fixes a bug where header keys from the new Socket class weren't getting converted to lowercase so `headers["cookie"]` was not finding the header `"Cookie"`. We should write a test to make sure this doesn't break again.

@qutheory/vapor Let me know what you think.