### PR TITLE
move assignment for server.delegate

### DIFF
--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -109,6 +109,7 @@ public class Application {
 		self.providers = []
 
 		self.middleware.append(SessionMiddleware)
+		self.server.delegate = self
 	}
 
 	public func bootProviders() {
@@ -181,7 +182,6 @@ public class Application {
 	*/
 	public func start(ip ip: String? = nil, port: Int? = nil) {
 		self.bootProviders()
-		self.server.delegate = self
 
 		self.ip = ip ?? self.ip
 		self.port = port ?? self.port


### PR DESCRIPTION
I want to replace `app.server.delegate` before `app.start()`, but `app.server.delegate` is set app itself in `app.start()`.

If I could move the assignment from `start` to initializer, I can replace `app.server.delegate` with my custom delegate instance and continue using `SocketServer`.