### PR TITLE
Lock Hummingbird with minor version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ let package = Package(
     name: "Vapor",
     dependencies: [
         .Package(url: "https://github.com/qutheory/json.git", majorVersion: 0),
-        .Package(url: "https://github.com/ketzusaka/Hummingbird", majorVersion: 1)
+        .Package(url: "https://github.com/ketzusaka/Hummingbird", majorVersion: 1, minor: 0)
     ],
     exclude: [],
     targets: [


### PR DESCRIPTION
I'll be updating Hummingbird/Strand to 1.1 soon, which will be compatible with Swift 2.2 and the 03-16 dev snapshot. By locking on 1.0, Vapor will continue to work under the 03-01 snapshot, and when its ready for 03-16, it can update to 1.1.