### PR TITLE
updates link to vapor docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This is a work in progress, so *do not* rely on this for anything important. And
 
 ## Documentation
 
-Visit the [Documentation](http://docs.qutheory.io) for extensive documentation on getting setup, using, and contributing to Vapor.
+Visit the [Documentation](https://vapor.readme.io/docs) for extensive documentation on getting setup, using, and contributing to Vapor.
 
 ## Installation
 
@@ -64,7 +64,7 @@ Simply add Vapor as a dependency to your project's `Package.swift`.
 .Package(url: "https://github.com/qutheory/vapor.git", majorVersion: 0)
 ```
 
-For more detailed installation instructions, visit the Getting Started section in the [Documentation](https://docs.qutheory.io).
+For more detailed installation instructions, visit the Getting Started section in the [Documentation](https://vapor.readme.io/docs).
 
 ## Application
 


### PR DESCRIPTION
link to docs was broken, I've updated to https://vapor.readme.io/docs which is the new location of docs I guess.