### PR TITLE
More Swift 04-25 updates 

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,16 +4,16 @@ let package = Package(
     name: "Vapor",
     dependencies: [
         //Standards package. Contains protocols for cross-project compatability.
-        .Package(url: "https://github.com/open-swift/S4.git", majorVersion: 0, minor: 4),
+        .Package(url: "https://github.com/open-swift/S4.git", majorVersion: 0, minor: 5),
 
         //Provides critical String functions Foundation is missing on Linux
         .Package(url: "https://github.com/Zewo/String.git", majorVersion: 0, minor: 5),
 
         //Parses and serializes JSON
-        .Package(url: "https://github.com/Zewo/JSON.git", majorVersion: 0, minor: 5),
+        .Package(url: "https://github.com/Zewo/JSON.git", majorVersion: 0, minor: 6),
 
         //Swift wrapper around Sockets, used for built-in HTTP server
-        .Package(url: "https://github.com/ketzusaka/Hummingbird.git", majorVersion: 1, minor: 4),
+        .Package(url: "https://github.com/czechboy0/Hummingbird.git", majorVersion: 1, minor: 5),
 
         //SHA2 + HMAC hashing. Used by the core to create session identifiers.
         .Package(url: "https://github.com/CryptoKitten/HMAC.git", majorVersion: 0, minor: 5),

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
         .Package(url: "https://github.com/Zewo/JSON.git", majorVersion: 0, minor: 6),
 
         //Swift wrapper around Sockets, used for built-in HTTP server
-        .Package(url: "https://github.com/czechboy0/Hummingbird.git", majorVersion: 1, minor: 5),
+        .Package(url: "https://github.com/ketzusaka/Hummingbird.git", majorVersion: 1, minor: 5),
 
         //SHA2 + HMAC hashing. Used by the core to create session identifiers.
         .Package(url: "https://github.com/CryptoKitten/HMAC.git", majorVersion: 0, minor: 5),

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -40,7 +40,7 @@ app.get("json") { request in
         "number": 123,
         "text": "unicorns",
         "bool": false,
-        "nested": ["one", 2, false]
+        "nested": Json(["one", 2, false])
     ])
 }
 

--- a/Sources/Vapor/JSON/JSON.swift
+++ b/Sources/Vapor/JSON/JSON.swift
@@ -195,6 +195,12 @@ extension Bool: JsonRepresentable {
     }
 }
 
+extension Json: JsonRepresentable {
+    public func makeJson() -> Json {
+        return self
+    }
+}
+
 extension Json: CustomStringConvertible {
     public var description: String {
         return makeZewoJson().description

--- a/Tests/Vapor/ConfigTests.swift
+++ b/Tests/Vapor/ConfigTests.swift
@@ -12,13 +12,11 @@ class ConfigTests: XCTestCase {
         ]
     }
 
-    #if Xcode
-    //Xcode doesn't allow a working directory to be set, so this needs to be
-    //hardcoded unfortunately.
-    let workDir = "/Users/tanner/Developer/vapor/vapor/Sources/Development/"
-    #else
-    let workDir = "Sources/Development/"
-    #endif
+    var workDir: String {
+        let parent = #file.characters.split(separator: "/").map(String.init).dropLast().joined(separator: "/")
+        let path = "/\(parent)/../../Sources/Development/"
+        return path
+    }
 
 	func testSimple() {
 		let config = makeConfig(.Development, workDir: workDir)

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -7,71 +7,89 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		805D7FDD1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FDE1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FDF1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FE01CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D7FE11CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D7FE21CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D7FE31CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D7FE41CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FE51CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		805D7FE61CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		805D7FE71CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		805D7FE81CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		805D7FE91CC9AE2C003B9A5C /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		805D7FEA1CC9AE2C003B9A5C /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		805D7FEB1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
-		805D7FEC1CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D7FED1CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D7FEE1CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D7FEF1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FF01CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		805D7FF11CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		805D7FF21CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		805D7FF31CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		805D7FF41CC9AE2C003B9A5C /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		805D7FF51CC9AE2C003B9A5C /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		805D7FF61CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D7FF71CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D7FF81CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D7FF91CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FFA1CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D7FFB1CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D7FFC1CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D7FFD1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D7FFE1CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		805D7FFF1CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		805D80001CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		805D80011CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		805D80021CC9AE2C003B9A5C /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		805D80031CC9AE2C003B9A5C /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		805D80041CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D80051CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D80061CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D80071CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D80081CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		805D80091CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		805D800A1CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		805D800B1CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		805D800C1CC9AE2C003B9A5C /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		805D800D1CC9AE2C003B9A5C /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		805D800E1CC9AE2C003B9A5C /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
-		805D800F1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
-		805D80101CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		805D80111CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		805D80121CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		805D80131CC9AE2C003B9A5C /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		805D80141CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		805D80151CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		805D80161CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		805D80171CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		805D80181CC9AE2C003B9A5C /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		805D80191CC9AE2C003B9A5C /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		805D801A1CC9AE2C003B9A5C /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
-		805D801B1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A9097121CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097131CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097141CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097151CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097161CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9097171CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9097181CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097191CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A90971A1CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A90971B1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A90971C1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A90971D1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A90971E1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A90971F1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097201CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9097211CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9097221CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9097231CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9097241CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9097251CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9097261CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A9097271CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9097281CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097291CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A90972A1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A90972B1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A90972C1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A90972D1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A90972E1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A90972F1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9097301CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9097311CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9097321CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9097331CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9097341CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097351CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9097361CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9097371CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9097381CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097391CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A90973A1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A90973B1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A90973C1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A90973D1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A90973E1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A90973F1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9097401CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9097411CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9097421CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9097431CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9097441CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9097451CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9097461CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097471CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9097481CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9097491CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A90974A1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A90974B1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A90974C1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A90974D1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A90974E1CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A90974F1CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9097501CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9097511CD4D5790061FA2D /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
+		3A9097521CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A9097531CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9097541CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9097551CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9097561CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9097571CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9097581CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9097591CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A90975A1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A90975B1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A90975C1CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A90975D1CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A90975E1CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A90975F1CD4D5790061FA2D /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
+		3A9097601CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
 		_LinkFileRef_C7 /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
 		_LinkFileRef_CryptoEssentials /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		_LinkFileRef_CryptoEssentialsSwift2 /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		_LinkFileRef_CryptoEssentialsSwift3 /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
 		_LinkFileRef_HMAC /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
 		_LinkFileRef_Hummingbird /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
 		_LinkFileRef_JSON /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
@@ -82,72 +100,84 @@
 		_LinkFileRef_StructuredData /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
 		_LinkFileRef_Vapor /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
 		_LinkFileRef_libc /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncHost.swift" /* AsyncHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncHost.swift" /* AsyncHost.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncStream.swift" /* AsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncStream.swift" /* AsyncStream.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Byte.swift" /* Byte.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Byte.swift" /* Byte.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/C7.swift" /* C7.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/C7.swift" /* C7.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Closable.swift" /* Closable.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Closable.swift" /* Closable.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Connection.swift" /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Connection.swift" /* Connection.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Data.swift" /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Data.swift" /* Data.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Drain.swift" /* Drain.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Drain.swift" /* Drain.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Host.swift" /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Host.swift" /* Host.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Query.swift" /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Query.swift" /* Query.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/QueryField.swift" /* QueryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/QueryField.swift" /* QueryField.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Stream.swift" /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Stream.swift" /* Stream.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/StreamError.swift" /* StreamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/StreamError.swift" /* StreamError.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/StreamSequence.swift" /* StreamSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/StreamSequence.swift" /* StreamSequence.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/Time.swift" /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/Time.swift" /* Time.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/URI.swift" /* URI.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/URI.swift" /* URI.swift */; };
-		"__src_cc_ref_Packages/C7-0.5.0/Sources/URIConnection.swift" /* URIConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.5.0/Sources/URIConnection.swift" /* URIConnection.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/BytesSequence.swift" /* BytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/BytesSequence.swift" /* BytesSequence.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Generics.swift" /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Generics.swift" /* Generics.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/HashProtocol.swift" /* HashProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/HashProtocol.swift" /* HashProtocol.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/IntExtension.swift" /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntExtension.swift" /* IntExtension.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntegerConvertible.swift" /* IntegerConvertible.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/NSData+Extensions.swift" /* NSData+Extensions.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Operators.swift" /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Operators.swift" /* Operators.swift */; };
-		"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Utils.swift" /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Utils.swift" /* Utils.swift */; };
-		"__src_cc_ref_Packages/HMAC-0.4.0/Sources/HMAC.swift" /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/HMAC-0.4.0/Sources/HMAC.swift" /* HMAC.swift */; };
-		"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/Socket.swift" /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/Socket.swift" /* Socket.swift */; };
-		"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/SocketError.swift" /* SocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/SocketError.swift" /* SocketError.swift */; };
-		"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */; };
-		"__src_cc_ref_Packages/JSON-0.5.0/Source/JSON.swift" /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.5.0/Source/JSON.swift" /* JSON.swift */; };
-		"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */; };
-		"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */; };
-		"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONParser.swift" /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.5.0/Source/JSONParser.swift" /* JSONParser.swift */; };
-		"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONSerializer.swift" /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.5.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncClient.swift" /* AsyncClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncClient.swift" /* AsyncClient.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncServer.swift" /* AsyncServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncServer.swift" /* AsyncServer.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Body.swift" /* Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Body.swift" /* Body.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Client.swift" /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Client.swift" /* Client.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Error.swift" /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Error.swift" /* Error.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Header.swift" /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Header.swift" /* Header.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Headers.swift" /* Headers.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Headers.swift" /* Headers.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Message.swift" /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Message.swift" /* Message.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Method.swift" /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Method.swift" /* Method.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Middleware.swift" /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Middleware.swift" /* Middleware.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Request.swift" /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Request.swift" /* Request.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/RequestParser.swift" /* RequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/RequestParser.swift" /* RequestParser.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Responder.swift" /* Responder.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Responder.swift" /* Responder.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Response.swift" /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Response.swift" /* Response.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/ResponseParser.swift" /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseParser.swift" /* ResponseParser.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/S4.swift" /* S4.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/S4.swift" /* S4.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Server.swift" /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Server.swift" /* Server.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Status.swift" /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Status.swift" /* Status.swift */; };
-		"__src_cc_ref_Packages/S4-0.4.0/Sources/Version.swift" /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.4.0/Sources/Version.swift" /* Version.swift */; };
-		"__src_cc_ref_Packages/SHA2-0.3.1/Sources/SHA2.swift" /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/SHA2-0.3.1/Sources/SHA2.swift" /* SHA2.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncHost.swift" /* AsyncHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncHost.swift" /* AsyncHost.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncStream.swift" /* AsyncStream.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncStream.swift" /* AsyncStream.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Byte.swift" /* Byte.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Byte.swift" /* Byte.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/C7.swift" /* C7.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/C7.swift" /* C7.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Closable.swift" /* Closable.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Closable.swift" /* Closable.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Connection.swift" /* Connection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Connection.swift" /* Connection.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Data.swift" /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Data.swift" /* Data.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Drain.swift" /* Drain.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Drain.swift" /* Drain.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Host.swift" /* Host.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Host.swift" /* Host.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Query.swift" /* Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Query.swift" /* Query.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/QueryField.swift" /* QueryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/QueryField.swift" /* QueryField.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Stream.swift" /* Stream.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Stream.swift" /* Stream.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/StreamError.swift" /* StreamError.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/StreamError.swift" /* StreamError.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/StreamSequence.swift" /* StreamSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/StreamSequence.swift" /* StreamSequence.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/Time.swift" /* Time.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/Time.swift" /* Time.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/URI.swift" /* URI.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/URI.swift" /* URI.swift */; };
+		"__src_cc_ref_Packages/C7-0.6.0/Sources/URIConnection.swift" /* URIConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/C7-0.6.0/Sources/URIConnection.swift" /* URIConnection.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials/CryptoEssentials.swift" /* CryptoEssentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials/CryptoEssentials.swift" /* CryptoEssentials.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Base64.swift" /* Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Base64.swift" /* Base64.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/BytesSequence.swift" /* BytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/BytesSequence.swift" /* BytesSequence.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Generics.swift" /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Generics.swift" /* Generics.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/HashProtocol.swift" /* HashProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/HashProtocol.swift" /* HashProtocol.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntExtension.swift" /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntExtension.swift" /* IntExtension.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntegerConvertible.swift" /* IntegerConvertible.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/NSData+Extensions.swift" /* NSData+Extensions.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Operators.swift" /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Operators.swift" /* Operators.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Utils.swift" /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Utils.swift" /* Utils.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Base64.swift" /* Base64.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Base64.swift" /* Base64.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/BytesSequence.swift" /* BytesSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/BytesSequence.swift" /* BytesSequence.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Generics.swift" /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Generics.swift" /* Generics.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/HashProtocol.swift" /* HashProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/HashProtocol.swift" /* HashProtocol.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntExtension.swift" /* IntExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntExtension.swift" /* IntExtension.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntegerConvertible.swift" /* IntegerConvertible.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/NSData+Extensions.swift" /* NSData+Extensions.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Operators.swift" /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Operators.swift" /* Operators.swift */; };
+		"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Utils.swift" /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Utils.swift" /* Utils.swift */; };
+		"__src_cc_ref_Packages/HMAC-0.5.2/Sources/HMAC.swift" /* HMAC.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/HMAC-0.5.2/Sources/HMAC.swift" /* HMAC.swift */; };
+		"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/Socket.swift" /* Socket.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/Socket.swift" /* Socket.swift */; };
+		"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/SocketError.swift" /* SocketError.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/SocketError.swift" /* SocketError.swift */; };
+		"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */; };
+		"__src_cc_ref_Packages/JSON-0.6.0/Source/JSON.swift" /* JSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.6.0/Source/JSON.swift" /* JSON.swift */; };
+		"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */; };
+		"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */; };
+		"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONParser.swift" /* JSONParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.6.0/Source/JSONParser.swift" /* JSONParser.swift */; };
+		"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONSerializer.swift" /* JSONSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/JSON-0.6.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncClient.swift" /* AsyncClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncClient.swift" /* AsyncClient.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncServer.swift" /* AsyncServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncServer.swift" /* AsyncServer.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Body.swift" /* Body.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Body.swift" /* Body.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Client.swift" /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Client.swift" /* Client.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Error.swift" /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Error.swift" /* Error.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Header.swift" /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Header.swift" /* Header.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Headers.swift" /* Headers.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Headers.swift" /* Headers.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Message.swift" /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Message.swift" /* Message.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Method.swift" /* Method.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Method.swift" /* Method.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Middleware.swift" /* Middleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Middleware.swift" /* Middleware.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Request.swift" /* Request.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Request.swift" /* Request.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/RequestParser.swift" /* RequestParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/RequestParser.swift" /* RequestParser.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Responder.swift" /* Responder.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Responder.swift" /* Responder.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Response.swift" /* Response.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Response.swift" /* Response.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/ResponseParser.swift" /* ResponseParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseParser.swift" /* ResponseParser.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/S4.swift" /* S4.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/S4.swift" /* S4.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Server.swift" /* Server.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Server.swift" /* Server.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Status.swift" /* Status.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Status.swift" /* Status.swift */; };
+		"__src_cc_ref_Packages/S4-0.5.0/Sources/Version.swift" /* Version.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/S4-0.5.0/Sources/Version.swift" /* Version.swift */; };
+		"__src_cc_ref_Packages/SHA2-0.5.1/Sources/SHA2.swift" /* SHA2.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/SHA2-0.5.1/Sources/SHA2.swift" /* SHA2.swift */; };
 		"__src_cc_ref_Packages/Strand-1.2.3/Sources/Strand.swift" /* Strand.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/Strand-1.2.3/Sources/Strand.swift" /* Strand.swift */; };
-		"__src_cc_ref_Packages/String-0.5.0/Source/String.swift" /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/String-0.5.0/Source/String.swift" /* String.swift */; };
-		"__src_cc_ref_Packages/StructuredData-0.5.0/Sources/StructuredData.swift" /* StructuredData.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/StructuredData-0.5.0/Sources/StructuredData.swift" /* StructuredData.swift */; };
+		"__src_cc_ref_Packages/String-0.5.1/Source/String.swift" /* String.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/String-0.5.1/Source/String.swift" /* String.swift */; };
+		"__src_cc_ref_Packages/StructuredData-0.6.0/Sources/StructuredData.swift" /* StructuredData.swift in Sources */ = {isa = PBXBuildFile; fileRef = "__PBXFileRef_Packages/StructuredData-0.6.0/Sources/StructuredData.swift" /* StructuredData.swift */; };
 		__src_cc_ref_Sources/Development/Controllers/UserController.swift /* Controllers/UserController.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Development/Controllers/UserController.swift /* Controllers/UserController.swift */; };
 		__src_cc_ref_Sources/Development/Middleware/AuthMiddleware.swift /* Middleware/AuthMiddleware.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Development/Middleware/AuthMiddleware.swift /* Middleware/AuthMiddleware.swift */; };
 		__src_cc_ref_Sources/Development/Models/User.swift /* Models/User.swift in Sources */ = {isa = PBXBuildFile; fileRef = __PBXFileRef_Sources/Development/Models/User.swift /* Models/User.swift */; };
@@ -223,84 +253,98 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		805D801C1CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097611CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_C7";
 			remoteInfo = C7;
 		};
-		805D801D1CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097621CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_StructuredData";
 			remoteInfo = StructuredData;
 		};
-		805D801E1CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097631CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Strand";
 			remoteInfo = Strand;
 		};
-		805D801F1CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097641CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = __RootObject_ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "______Target_CryptoEssentialsSwift2";
+			remoteInfo = CryptoEssentialsSwift2;
+		};
+		3A9097651CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = __RootObject_ /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = "______Target_CryptoEssentialsSwift3";
+			remoteInfo = CryptoEssentialsSwift3;
+		};
+		3A9097661CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_CryptoEssentials";
 			remoteInfo = CryptoEssentials;
 		};
-		805D80201CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097671CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_SHA2";
 			remoteInfo = SHA2;
 		};
-		805D80211CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097681CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_HMAC";
 			remoteInfo = HMAC;
 		};
-		805D80221CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A9097691CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Hummingbird";
 			remoteInfo = Hummingbird;
 		};
-		805D80231CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A90976A1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_JSON";
 			remoteInfo = JSON;
 		};
-		805D80241CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A90976B1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_String";
 			remoteInfo = String;
 		};
-		805D80251CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A90976C1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_S4";
 			remoteInfo = S4;
 		};
-		805D80261CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A90976D1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Vapor";
 			remoteInfo = Vapor;
 		};
-		805D80271CC9AE2C003B9A5C /* PBXContainerItemProxy */ = {
+		3A90976E1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
@@ -310,73 +354,85 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = /Users/loganwright/Dropbox/Programming/xCode/vapor/Package.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncConnection.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncHost.swift" /* AsyncHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHost.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncStream.swift" /* AsyncStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStream.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncURIConnection.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Byte.swift" /* Byte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Byte.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/C7.swift" /* C7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C7.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseInsensitiveString.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Closable.swift" /* Closable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Closable.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Connection.swift" /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDataStore.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Data.swift" /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Drain.swift" /* Drain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drain.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Host.swift" /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Query.swift" /* Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/QueryField.swift" /* QueryField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryField.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Stream.swift" /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/StreamError.swift" /* StreamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamError.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/StreamSequence.swift" /* StreamSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamSequence.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/Time.swift" /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Time.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/URI.swift" /* URI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URI.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/C7-0.5.0/Sources/URIConnection.swift" /* URIConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URIConnection.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/BytesSequence.swift" /* BytesSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesSequence.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSArrayType+Extension.swift"; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Generics.swift" /* Generics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generics.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/HashProtocol.swift" /* HashProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashProtocol.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntExtension.swift" /* IntExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntegerConvertible.swift" /* IntegerConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerConvertible.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/NSData+Extensions.swift" /* NSData+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSData+Extensions.swift"; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Operators.swift" /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Utils.swift" /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/HMAC-0.4.0/Sources/HMAC.swift" /* HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/Socket.swift" /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/SocketError.swift" /* SocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketError.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Transcoding.swift"; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/JSON-0.5.0/Source/JSON.swift" /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONInterchangeDataParser.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONInterchangeDataSerializer.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONParser.swift" /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncClient.swift" /* AsyncClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncClient.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncMiddleware.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncResponder.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncServer.swift" /* AsyncServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncServer.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Body.swift" /* Body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Body.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Client.swift" /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Error.swift" /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Header.swift" /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Headers.swift" /* Headers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Headers.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Message.swift" /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Method.swift" /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Middleware.swift" /* Middleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Middleware.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Request.swift" /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/RequestParser.swift" /* RequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestParser.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestSerializer.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Responder.swift" /* Responder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responder.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Response.swift" /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseParser.swift" /* ResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParser.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSerializer.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/S4.swift" /* S4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = S4.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Server.swift" /* Server.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Server.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Status.swift" /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/S4-0.4.0/Sources/Version.swift" /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/SHA2-0.3.1/Sources/SHA2.swift" /* SHA2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA2.swift; sourceTree = "<group>"; };
+		__PBXFileRef_Package.swift /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = Package.swift; path = /Users/honzadvorsky/Documents/qutheory/vapor/Package.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncConnection.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncHost.swift" /* AsyncHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncHost.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncStream.swift" /* AsyncStream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncStream.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncURIConnection.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Byte.swift" /* Byte.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Byte.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/C7.swift" /* C7.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = C7.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaseInsensitiveString.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Closable.swift" /* Closable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Closable.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Connection.swift" /* Connection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Connection.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomDataStore.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Data.swift" /* Data.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Drain.swift" /* Drain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Drain.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Host.swift" /* Host.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Host.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Query.swift" /* Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Query.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/QueryField.swift" /* QueryField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QueryField.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Stream.swift" /* Stream.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stream.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/StreamError.swift" /* StreamError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamError.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/StreamSequence.swift" /* StreamSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StreamSequence.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/Time.swift" /* Time.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Time.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/URI.swift" /* URI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URI.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/C7-0.6.0/Sources/URIConnection.swift" /* URIConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URIConnection.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials/CryptoEssentials.swift" /* CryptoEssentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoEssentials.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Base64.swift" /* Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/BytesSequence.swift" /* BytesSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesSequence.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSArrayType+Extension.swift"; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Generics.swift" /* Generics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generics.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/HashProtocol.swift" /* HashProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashProtocol.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntExtension.swift" /* IntExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntegerConvertible.swift" /* IntegerConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerConvertible.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/NSData+Extensions.swift" /* NSData+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSData+Extensions.swift"; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Operators.swift" /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Utils.swift" /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Base64.swift" /* Base64.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Base64.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/BytesSequence.swift" /* BytesSequence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BytesSequence.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CSArrayType+Extension.swift"; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Generics.swift" /* Generics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generics.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/HashProtocol.swift" /* HashProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashProtocol.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntExtension.swift" /* IntExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntExtension.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntegerConvertible.swift" /* IntegerConvertible.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntegerConvertible.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/NSData+Extensions.swift" /* NSData+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSData+Extensions.swift"; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Operators.swift" /* Operators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Operators.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Utils.swift" /* Utils.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/HMAC-0.5.2/Sources/HMAC.swift" /* HMAC.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HMAC.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/Socket.swift" /* Socket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Socket.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/SocketError.swift" /* SocketError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketError.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String+Transcoding.swift"; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/JSON-0.6.0/Source/JSON.swift" /* JSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSON.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONInterchangeDataParser.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONInterchangeDataSerializer.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONParser.swift" /* JSONParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONParser.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONSerializer.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncClient.swift" /* AsyncClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncClient.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncMiddleware.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncResponder.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncServer.swift" /* AsyncServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncServer.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Body.swift" /* Body.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Body.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Client.swift" /* Client.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Client.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Error.swift" /* Error.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Error.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Header.swift" /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Headers.swift" /* Headers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Headers.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Message.swift" /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Method.swift" /* Method.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Method.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Middleware.swift" /* Middleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Middleware.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Request.swift" /* Request.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Request.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/RequestParser.swift" /* RequestParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestParser.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RequestSerializer.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Responder.swift" /* Responder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Responder.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Response.swift" /* Response.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Response.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseParser.swift" /* ResponseParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseParser.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResponseSerializer.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/S4.swift" /* S4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = S4.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Server.swift" /* Server.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Server.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Status.swift" /* Status.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Status.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/S4-0.5.0/Sources/Version.swift" /* Version.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Version.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/SHA2-0.5.1/Sources/SHA2.swift" /* SHA2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SHA2.swift; sourceTree = "<group>"; };
 		"__PBXFileRef_Packages/Strand-1.2.3/Sources/Strand.swift" /* Strand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Strand.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/String-0.5.0/Source/String.swift" /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
-		"__PBXFileRef_Packages/StructuredData-0.5.0/Sources/StructuredData.swift" /* StructuredData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuredData.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/String-0.5.1/Source/String.swift" /* String.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = String.swift; sourceTree = "<group>"; };
+		"__PBXFileRef_Packages/StructuredData-0.6.0/Sources/StructuredData.swift" /* StructuredData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StructuredData.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Development/Controllers/UserController.swift /* Controllers/UserController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Controllers/UserController.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Development/Middleware/AuthMiddleware.swift /* Middleware/AuthMiddleware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Middleware/AuthMiddleware.swift; sourceTree = "<group>"; };
 		__PBXFileRef_Sources/Development/Models/User.swift /* Models/User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Models/User.swift; sourceTree = "<group>"; };
@@ -451,6 +507,8 @@
 		__PBXFileRef_Tests/Vapor/TypedRouteTests.swift /* TypedRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TypedRouteTests.swift; sourceTree = "<group>"; };
 		"_____Product_C7" /* libC7.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libC7.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libCryptoEssentials.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libCryptoEssentialsSwift2.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libCryptoEssentialsSwift3.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_Development" /* Development */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = Development; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_Generator" /* Generator */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; path = Generator; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_HMAC" /* libHMAC.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libHMAC.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -463,7 +521,7 @@
 		"_____Product_String" /* libString.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libString.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_StructuredData" /* libStructuredData.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libStructuredData.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_Vapor" /* libVapor.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = libVapor.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
-		"_____Product_VaporTestSuite" /* VaporTestSuite.xctest */ = {isa = PBXFileReference; lastKnownFileType = file; name = VaporTestSuite.xctest; path = Vapor.testsuite.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		"_____Product_VaporTestSuite" /* Vapor.testsuite.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; path = Vapor.testsuite.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		"_____Product_libc" /* liblibc.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; path = liblibc.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -479,6 +537,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
+				_LinkFileRef_CryptoEssentialsSwift2 /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				_LinkFileRef_CryptoEssentialsSwift3 /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		"___LinkPhase_CryptoEssentialsSwift2" /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		"___LinkPhase_CryptoEssentialsSwift3" /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 0;
+			files = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -486,18 +560,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FE11CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D7FE21CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D7FE31CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D7FE41CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
-				805D7FE51CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */,
-				805D7FE61CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */,
-				805D7FE71CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */,
-				805D7FE81CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */,
-				805D7FE91CC9AE2C003B9A5C /* libString.dylib in Frameworks */,
-				805D7FEA1CC9AE2C003B9A5C /* libS4.dylib in Frameworks */,
+				3A90971A1CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A90971B1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A90971C1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A90971D1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A90971E1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A90971F1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A9097201CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
+				3A9097211CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
+				3A9097221CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
+				3A9097231CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
+				3A9097241CD4D5790061FA2D /* libString.dylib in Frameworks */,
+				3A9097251CD4D5790061FA2D /* libS4.dylib in Frameworks */,
 				_LinkFileRef_Vapor /* libVapor.dylib in Frameworks */,
-				805D7FEB1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */,
+				3A9097261CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -505,16 +581,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FFA1CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D7FFB1CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D7FFC1CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D7FFD1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
-				805D7FFE1CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */,
-				805D7FFF1CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */,
-				805D80001CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */,
-				805D80011CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */,
-				805D80021CC9AE2C003B9A5C /* libString.dylib in Frameworks */,
-				805D80031CC9AE2C003B9A5C /* libS4.dylib in Frameworks */,
+				3A9097391CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A90973A1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A90973B1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A90973C1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A90973D1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A90973E1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A90973F1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
+				3A9097401CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
+				3A9097411CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
+				3A9097421CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
+				3A9097431CD4D5790061FA2D /* libString.dylib in Frameworks */,
+				3A9097441CD4D5790061FA2D /* libS4.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -523,6 +601,8 @@
 			buildActionMask = 0;
 			files = (
 				_LinkFileRef_CryptoEssentials /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097151CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097161CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -530,7 +610,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FDF1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
+				3A9097141CD4D5790061FA2D /* libC7.dylib in Frameworks */,
 				_LinkFileRef_Strand /* libStrand.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -539,7 +619,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FDE1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
+				3A9097131CD4D5790061FA2D /* libC7.dylib in Frameworks */,
 				_LinkFileRef_StructuredData /* libStructuredData.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -548,18 +628,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D80041CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D80051CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D80061CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D80071CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
-				805D80081CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */,
-				805D80091CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */,
-				805D800A1CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */,
-				805D800B1CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */,
-				805D800C1CC9AE2C003B9A5C /* libString.dylib in Frameworks */,
-				805D800D1CC9AE2C003B9A5C /* libS4.dylib in Frameworks */,
-				805D800E1CC9AE2C003B9A5C /* libVapor.dylib in Frameworks */,
-				805D800F1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */,
+				3A9097451CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097461CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097471CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9097481CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A9097491CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A90974A1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A90974B1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
+				3A90974C1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
+				3A90974D1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
+				3A90974E1CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
+				3A90974F1CD4D5790061FA2D /* libString.dylib in Frameworks */,
+				3A9097501CD4D5790061FA2D /* libS4.dylib in Frameworks */,
+				3A9097511CD4D5790061FA2D /* libVapor.dylib in Frameworks */,
+				3A9097521CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -575,7 +657,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FE01CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097171CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097181CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097191CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -597,7 +681,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FDD1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
+				3A9097121CD4D5790061FA2D /* libC7.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -605,16 +689,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FEC1CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D7FED1CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D7FEE1CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D7FEF1CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
-				805D7FF01CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */,
-				805D7FF11CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */,
-				805D7FF21CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */,
-				805D7FF31CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */,
-				805D7FF41CC9AE2C003B9A5C /* libString.dylib in Frameworks */,
-				805D7FF51CC9AE2C003B9A5C /* libS4.dylib in Frameworks */,
+				3A9097271CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097281CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097291CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A90972A1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A90972B1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A90972C1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A90972D1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
+				3A90972E1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
+				3A90972F1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
+				3A9097301CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
+				3A9097311CD4D5790061FA2D /* libString.dylib in Frameworks */,
+				3A9097321CD4D5790061FA2D /* libS4.dylib in Frameworks */,
 				_LinkFileRef_libc /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -623,18 +709,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D80101CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D80111CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D80121CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D80131CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
-				805D80141CC9AE2C003B9A5C /* libSHA2.dylib in Frameworks */,
-				805D80151CC9AE2C003B9A5C /* libHMAC.dylib in Frameworks */,
-				805D80161CC9AE2C003B9A5C /* libHummingbird.dylib in Frameworks */,
-				805D80171CC9AE2C003B9A5C /* libJSON.dylib in Frameworks */,
-				805D80181CC9AE2C003B9A5C /* libString.dylib in Frameworks */,
-				805D80191CC9AE2C003B9A5C /* libS4.dylib in Frameworks */,
-				805D801A1CC9AE2C003B9A5C /* libVapor.dylib in Frameworks */,
-				805D801B1CC9AE2C003B9A5C /* liblibc.dylib in Frameworks */,
+				3A9097531CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097541CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097551CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9097561CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A9097571CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A9097581CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A9097591CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
+				3A90975A1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
+				3A90975B1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
+				3A90975C1CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
+				3A90975D1CD4D5790061FA2D /* libString.dylib in Frameworks */,
+				3A90975E1CD4D5790061FA2D /* libS4.dylib in Frameworks */,
+				3A90975F1CD4D5790061FA2D /* libVapor.dylib in Frameworks */,
+				3A9097601CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -642,10 +730,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				805D7FF61CC9AE2C003B9A5C /* libCryptoEssentials.dylib in Frameworks */,
-				805D7FF71CC9AE2C003B9A5C /* libStrand.dylib in Frameworks */,
-				805D7FF81CC9AE2C003B9A5C /* libStructuredData.dylib in Frameworks */,
-				805D7FF91CC9AE2C003B9A5C /* libC7.dylib in Frameworks */,
+				3A9097331CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
+				3A9097341CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9097351CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9097361CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
+				3A9097371CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
+				3A9097381CD4D5790061FA2D /* libC7.dylib in Frameworks */,
 				_LinkFileRef_SHA2 /* libSHA2.dylib in Frameworks */,
 				_LinkFileRef_HMAC /* libHMAC.dylib in Frameworks */,
 				_LinkFileRef_Hummingbird /* libHummingbird.dylib in Frameworks */,
@@ -669,6 +759,8 @@
 				"_______Group_Strand" /* Strand */,
 				"_______Group_Hummingbird" /* Hummingbird */,
 				"_______Group_CryptoEssentials" /* CryptoEssentials */,
+				"_______Group_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */,
+				"_______Group_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */,
 				"_______Group_HMAC" /* HMAC */,
 				"_______Group_SHA2" /* SHA2 */,
 			);
@@ -678,7 +770,7 @@
 		TestProducts_ /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				"_____Product_VaporTestSuite" /* VaporTestSuite.xctest */,
+				"_____Product_VaporTestSuite" /* Vapor.testsuite.xctest */,
 			);
 			name = Tests;
 			sourceTree = "<group>";
@@ -706,6 +798,8 @@
 				"_____Product_Strand" /* libStrand.dylib */,
 				"_____Product_Hummingbird" /* libHummingbird.dylib */,
 				"_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */,
+				"_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */,
+				"_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */,
 				"_____Product_HMAC" /* libHMAC.dylib */,
 				"_____Product_SHA2" /* libSHA2.dylib */,
 				"_____Product_Development" /* Development */,
@@ -732,47 +826,75 @@
 		"_______Group_C7" /* C7 */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncHost.swift" /* AsyncHost.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncStream.swift" /* AsyncStream.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Byte.swift" /* Byte.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/C7.swift" /* C7.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Closable.swift" /* Closable.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Connection.swift" /* Connection.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Data.swift" /* Data.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Drain.swift" /* Drain.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Host.swift" /* Host.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Query.swift" /* Query.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/QueryField.swift" /* QueryField.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Stream.swift" /* Stream.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/StreamError.swift" /* StreamError.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/StreamSequence.swift" /* StreamSequence.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/Time.swift" /* Time.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/URI.swift" /* URI.swift */,
-				"__PBXFileRef_Packages/C7-0.5.0/Sources/URIConnection.swift" /* URIConnection.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncHost.swift" /* AsyncHost.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncStream.swift" /* AsyncStream.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Byte.swift" /* Byte.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/C7.swift" /* C7.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Closable.swift" /* Closable.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Connection.swift" /* Connection.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Data.swift" /* Data.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Drain.swift" /* Drain.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Host.swift" /* Host.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Query.swift" /* Query.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/QueryField.swift" /* QueryField.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Stream.swift" /* Stream.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/StreamError.swift" /* StreamError.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/StreamSequence.swift" /* StreamSequence.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/Time.swift" /* Time.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/URI.swift" /* URI.swift */,
+				"__PBXFileRef_Packages/C7-0.6.0/Sources/URIConnection.swift" /* URIConnection.swift */,
 			);
 			name = C7;
-			path = "Packages/C7-0.5.0/Sources";
+			path = "Packages/C7-0.6.0/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_CryptoEssentials" /* CryptoEssentials */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/BytesSequence.swift" /* BytesSequence.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Generics.swift" /* Generics.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/HashProtocol.swift" /* HashProtocol.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntegerConvertible.swift" /* IntegerConvertible.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/IntExtension.swift" /* IntExtension.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/NSData+Extensions.swift" /* NSData+Extensions.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Operators.swift" /* Operators.swift */,
-				"__PBXFileRef_Packages/CryptoEssentials-0.4.0/Sources/Utils.swift" /* Utils.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials/CryptoEssentials.swift" /* CryptoEssentials.swift */,
 			);
 			name = CryptoEssentials;
-			path = "Packages/CryptoEssentials-0.4.0/Sources";
+			path = "Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials";
+			sourceTree = "<group>";
+		};
+		"_______Group_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */ = {
+			isa = PBXGroup;
+			children = (
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Base64.swift" /* Base64.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/BytesSequence.swift" /* BytesSequence.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Generics.swift" /* Generics.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/HashProtocol.swift" /* HashProtocol.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntegerConvertible.swift" /* IntegerConvertible.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntExtension.swift" /* IntExtension.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/NSData+Extensions.swift" /* NSData+Extensions.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Operators.swift" /* Operators.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Utils.swift" /* Utils.swift */,
+			);
+			name = CryptoEssentialsSwift2;
+			path = "Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2";
+			sourceTree = "<group>";
+		};
+		"_______Group_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */ = {
+			isa = PBXGroup;
+			children = (
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Base64.swift" /* Base64.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/BytesSequence.swift" /* BytesSequence.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Generics.swift" /* Generics.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/HashProtocol.swift" /* HashProtocol.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntegerConvertible.swift" /* IntegerConvertible.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntExtension.swift" /* IntExtension.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/NSData+Extensions.swift" /* NSData+Extensions.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Operators.swift" /* Operators.swift */,
+				"__PBXFileRef_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Utils.swift" /* Utils.swift */,
+			);
+			name = CryptoEssentialsSwift3;
+			path = "Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3";
 			sourceTree = "<group>";
 		};
 		"_______Group_Development" /* Development */ = {
@@ -799,34 +921,34 @@
 		"_______Group_HMAC" /* HMAC */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/HMAC-0.4.0/Sources/HMAC.swift" /* HMAC.swift */,
+				"__PBXFileRef_Packages/HMAC-0.5.2/Sources/HMAC.swift" /* HMAC.swift */,
 			);
 			name = HMAC;
-			path = "Packages/HMAC-0.4.0/Sources";
+			path = "Packages/HMAC-0.5.2/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_Hummingbird" /* Hummingbird */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/Socket.swift" /* Socket.swift */,
-				"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/SocketError.swift" /* SocketError.swift */,
-				"__PBXFileRef_Packages/Hummingbird-1.4.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */,
+				"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/Socket.swift" /* Socket.swift */,
+				"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/SocketError.swift" /* SocketError.swift */,
+				"__PBXFileRef_Packages/Hummingbird-1.5.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift */,
 			);
 			name = Hummingbird;
-			path = "Packages/Hummingbird-1.4.0/Sources";
+			path = "Packages/Hummingbird-1.5.0/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_JSON" /* JSON */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/JSON-0.5.0/Source/JSON.swift" /* JSON.swift */,
-				"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */,
-				"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */,
-				"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONParser.swift" /* JSONParser.swift */,
-				"__PBXFileRef_Packages/JSON-0.5.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */,
+				"__PBXFileRef_Packages/JSON-0.6.0/Source/JSON.swift" /* JSON.swift */,
+				"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift */,
+				"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift */,
+				"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONParser.swift" /* JSONParser.swift */,
+				"__PBXFileRef_Packages/JSON-0.6.0/Source/JSONSerializer.swift" /* JSONSerializer.swift */,
 			);
 			name = JSON;
-			path = "Packages/JSON-0.5.0/Source";
+			path = "Packages/JSON-0.6.0/Source";
 			sourceTree = "<group>";
 		};
 		"_______Group_Performance" /* Performance */ = {
@@ -841,41 +963,41 @@
 		"_______Group_S4" /* S4 */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncClient.swift" /* AsyncClient.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/AsyncServer.swift" /* AsyncServer.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Body.swift" /* Body.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Client.swift" /* Client.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Error.swift" /* Error.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Header.swift" /* Header.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Headers.swift" /* Headers.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Message.swift" /* Message.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Method.swift" /* Method.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Middleware.swift" /* Middleware.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Request.swift" /* Request.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/RequestParser.swift" /* RequestParser.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Responder.swift" /* Responder.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Response.swift" /* Response.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseParser.swift" /* ResponseParser.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/S4.swift" /* S4.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Server.swift" /* Server.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Status.swift" /* Status.swift */,
-				"__PBXFileRef_Packages/S4-0.4.0/Sources/Version.swift" /* Version.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncClient.swift" /* AsyncClient.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/AsyncServer.swift" /* AsyncServer.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Body.swift" /* Body.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Client.swift" /* Client.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Error.swift" /* Error.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Header.swift" /* Header.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Headers.swift" /* Headers.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Message.swift" /* Message.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Method.swift" /* Method.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Middleware.swift" /* Middleware.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Request.swift" /* Request.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/RequestParser.swift" /* RequestParser.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Responder.swift" /* Responder.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Response.swift" /* Response.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseParser.swift" /* ResponseParser.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/S4.swift" /* S4.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Server.swift" /* Server.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Status.swift" /* Status.swift */,
+				"__PBXFileRef_Packages/S4-0.5.0/Sources/Version.swift" /* Version.swift */,
 			);
 			name = S4;
-			path = "Packages/S4-0.4.0/Sources";
+			path = "Packages/S4-0.5.0/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_SHA2" /* SHA2 */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/SHA2-0.3.1/Sources/SHA2.swift" /* SHA2.swift */,
+				"__PBXFileRef_Packages/SHA2-0.5.1/Sources/SHA2.swift" /* SHA2.swift */,
 			);
 			name = SHA2;
-			path = "Packages/SHA2-0.3.1/Sources";
+			path = "Packages/SHA2-0.5.1/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_Strand" /* Strand */ = {
@@ -890,19 +1012,19 @@
 		"_______Group_String" /* String */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/String-0.5.0/Source/String.swift" /* String.swift */,
+				"__PBXFileRef_Packages/String-0.5.1/Source/String.swift" /* String.swift */,
 			);
 			name = String;
-			path = "Packages/String-0.5.0/Source";
+			path = "Packages/String-0.5.1/Source";
 			sourceTree = "<group>";
 		};
 		"_______Group_StructuredData" /* StructuredData */ = {
 			isa = PBXGroup;
 			children = (
-				"__PBXFileRef_Packages/StructuredData-0.5.0/Sources/StructuredData.swift" /* StructuredData.swift */,
+				"__PBXFileRef_Packages/StructuredData-0.6.0/Sources/StructuredData.swift" /* StructuredData.swift */,
 			);
 			name = StructuredData;
-			path = "Packages/StructuredData-0.5.0/Sources";
+			path = "Packages/StructuredData-0.6.0/Sources";
 			sourceTree = "<group>";
 		};
 		"_______Group_Vapor" /* Vapor */ = {
@@ -1032,10 +1154,44 @@
 			buildRules = (
 			);
 			dependencies = (
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 			);
 			name = CryptoEssentials;
 			productName = CryptoEssentials;
 			productReference = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		"______Target_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = "_______Confs_CryptoEssentialsSwift2" /* Build configuration list for PBXNativeTarget "CryptoEssentialsSwift2" */;
+			buildPhases = (
+				CompilePhase_CryptoEssentialsSwift2 /* Sources */,
+				"___LinkPhase_CryptoEssentialsSwift2" /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CryptoEssentialsSwift2;
+			productName = CryptoEssentialsSwift2;
+			productReference = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */;
+			productType = "com.apple.product-type.library.dynamic";
+		};
+		"______Target_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = "_______Confs_CryptoEssentialsSwift3" /* Build configuration list for PBXNativeTarget "CryptoEssentialsSwift3" */;
+			buildPhases = (
+				CompilePhase_CryptoEssentialsSwift3 /* Sources */,
+				"___LinkPhase_CryptoEssentialsSwift3" /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = CryptoEssentialsSwift3;
+			productName = CryptoEssentialsSwift3;
+			productReference = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */;
 			productType = "com.apple.product-type.library.dynamic";
 		};
 		"______Target_Development" /* Development */ = {
@@ -1049,6 +1205,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1076,6 +1234,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1102,6 +1262,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 			);
 			name = HMAC;
 			productName = HMAC;
@@ -1155,6 +1317,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1199,6 +1363,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 			);
 			name = SHA2;
 			productName = SHA2;
@@ -1265,6 +1431,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1292,6 +1460,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1305,7 +1475,7 @@
 			);
 			name = Vapor.testsuite;
 			productName = VaporTestSuite;
-			productReference = "_____Product_VaporTestSuite" /* VaporTestSuite.xctest */;
+			productReference = "_____Product_VaporTestSuite" /* Vapor.testsuite.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		"______Target_libc" /* libc */ = {
@@ -1319,6 +1489,8 @@
 			);
 			dependencies = (
 				__Dependency_CryptoEssentials /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */,
+				__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */,
 				__Dependency_Strand /* PBXTargetDependency */,
 				__Dependency_StructuredData /* PBXTargetDependency */,
 				__Dependency_C7 /* PBXTargetDependency */,
@@ -1362,6 +1534,8 @@
 				"______Target_Strand" /* Strand */,
 				"______Target_Hummingbird" /* Hummingbird */,
 				"______Target_CryptoEssentials" /* CryptoEssentials */,
+				"______Target_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */,
+				"______Target_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */,
 				"______Target_HMAC" /* HMAC */,
 				"______Target_SHA2" /* SHA2 */,
 				"______Target_Development" /* Development */,
@@ -1379,27 +1553,27 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncHost.swift" /* AsyncHost.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncStream.swift" /* AsyncStream.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Byte.swift" /* Byte.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/C7.swift" /* C7.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Closable.swift" /* Closable.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Connection.swift" /* Connection.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Data.swift" /* Data.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Drain.swift" /* Drain.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Host.swift" /* Host.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Query.swift" /* Query.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/QueryField.swift" /* QueryField.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Stream.swift" /* Stream.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/StreamError.swift" /* StreamError.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/StreamSequence.swift" /* StreamSequence.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/Time.swift" /* Time.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/URI.swift" /* URI.swift in Sources */,
-				"__src_cc_ref_Packages/C7-0.5.0/Sources/URIConnection.swift" /* URIConnection.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncConnection.swift" /* AsyncConnection.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncHost.swift" /* AsyncHost.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncStream.swift" /* AsyncStream.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/AsyncURIConnection.swift" /* AsyncURIConnection.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Byte.swift" /* Byte.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/C7.swift" /* C7.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/CaseInsensitiveString.swift" /* CaseInsensitiveString.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Closable.swift" /* Closable.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Connection.swift" /* Connection.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/CustomDataStore.swift" /* CustomDataStore.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Data.swift" /* Data.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Drain.swift" /* Drain.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Host.swift" /* Host.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Query.swift" /* Query.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/QueryField.swift" /* QueryField.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Stream.swift" /* Stream.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/StreamError.swift" /* StreamError.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/StreamSequence.swift" /* StreamSequence.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/Time.swift" /* Time.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/URI.swift" /* URI.swift in Sources */,
+				"__src_cc_ref_Packages/C7-0.6.0/Sources/URIConnection.swift" /* URIConnection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1407,15 +1581,41 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/BytesSequence.swift" /* BytesSequence.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Generics.swift" /* Generics.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/HashProtocol.swift" /* HashProtocol.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/IntExtension.swift" /* IntExtension.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Operators.swift" /* Operators.swift in Sources */,
-				"__src_cc_ref_Packages/CryptoEssentials-0.4.0/Sources/Utils.swift" /* Utils.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentials/CryptoEssentials.swift" /* CryptoEssentials.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CompilePhase_CryptoEssentialsSwift2 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Base64.swift" /* Base64.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/BytesSequence.swift" /* BytesSequence.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Generics.swift" /* Generics.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/HashProtocol.swift" /* HashProtocol.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/IntExtension.swift" /* IntExtension.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Operators.swift" /* Operators.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift2/Utils.swift" /* Utils.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CompilePhase_CryptoEssentialsSwift3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 0;
+			files = (
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Base64.swift" /* Base64.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/BytesSequence.swift" /* BytesSequence.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/CSArrayType+Extension.swift" /* CSArrayType+Extension.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Generics.swift" /* Generics.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/HashProtocol.swift" /* HashProtocol.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntegerConvertible.swift" /* IntegerConvertible.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/IntExtension.swift" /* IntExtension.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/NSData+Extensions.swift" /* NSData+Extensions.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Operators.swift" /* Operators.swift in Sources */,
+				"__src_cc_ref_Packages/CryptoEssentials-0.5.2/Sources/CryptoEssentialsSwift3/Utils.swift" /* Utils.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1442,7 +1642,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/HMAC-0.4.0/Sources/HMAC.swift" /* HMAC.swift in Sources */,
+				"__src_cc_ref_Packages/HMAC-0.5.2/Sources/HMAC.swift" /* HMAC.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1450,9 +1650,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/Socket.swift" /* Socket.swift in Sources */,
-				"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/SocketError.swift" /* SocketError.swift in Sources */,
-				"__src_cc_ref_Packages/Hummingbird-1.4.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift in Sources */,
+				"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/Socket.swift" /* Socket.swift in Sources */,
+				"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/SocketError.swift" /* SocketError.swift in Sources */,
+				"__src_cc_ref_Packages/Hummingbird-1.5.0/Sources/String+Transcoding.swift" /* String+Transcoding.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1460,11 +1660,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/JSON-0.5.0/Source/JSON.swift" /* JSON.swift in Sources */,
-				"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift in Sources */,
-				"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift in Sources */,
-				"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONParser.swift" /* JSONParser.swift in Sources */,
-				"__src_cc_ref_Packages/JSON-0.5.0/Source/JSONSerializer.swift" /* JSONSerializer.swift in Sources */,
+				"__src_cc_ref_Packages/JSON-0.6.0/Source/JSON.swift" /* JSON.swift in Sources */,
+				"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONInterchangeDataParser.swift" /* JSONInterchangeDataParser.swift in Sources */,
+				"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONInterchangeDataSerializer.swift" /* JSONInterchangeDataSerializer.swift in Sources */,
+				"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONParser.swift" /* JSONParser.swift in Sources */,
+				"__src_cc_ref_Packages/JSON-0.6.0/Source/JSONSerializer.swift" /* JSONSerializer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1480,29 +1680,29 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncClient.swift" /* AsyncClient.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/AsyncServer.swift" /* AsyncServer.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Body.swift" /* Body.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Client.swift" /* Client.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Error.swift" /* Error.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Header.swift" /* Header.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Headers.swift" /* Headers.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Message.swift" /* Message.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Method.swift" /* Method.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Middleware.swift" /* Middleware.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Request.swift" /* Request.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/RequestParser.swift" /* RequestParser.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Responder.swift" /* Responder.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Response.swift" /* Response.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/ResponseParser.swift" /* ResponseParser.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/S4.swift" /* S4.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Server.swift" /* Server.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Status.swift" /* Status.swift in Sources */,
-				"__src_cc_ref_Packages/S4-0.4.0/Sources/Version.swift" /* Version.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncClient.swift" /* AsyncClient.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncMiddleware.swift" /* AsyncMiddleware.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncResponder.swift" /* AsyncResponder.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/AsyncServer.swift" /* AsyncServer.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Body.swift" /* Body.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Client.swift" /* Client.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Error.swift" /* Error.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Header.swift" /* Header.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Headers.swift" /* Headers.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Message.swift" /* Message.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Method.swift" /* Method.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Middleware.swift" /* Middleware.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Request.swift" /* Request.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/RequestParser.swift" /* RequestParser.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/RequestSerializer.swift" /* RequestSerializer.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Responder.swift" /* Responder.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Response.swift" /* Response.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/ResponseParser.swift" /* ResponseParser.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/ResponseSerializer.swift" /* ResponseSerializer.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/S4.swift" /* S4.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Server.swift" /* Server.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Status.swift" /* Status.swift in Sources */,
+				"__src_cc_ref_Packages/S4-0.5.0/Sources/Version.swift" /* Version.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1510,7 +1710,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/SHA2-0.3.1/Sources/SHA2.swift" /* SHA2.swift in Sources */,
+				"__src_cc_ref_Packages/SHA2-0.5.1/Sources/SHA2.swift" /* SHA2.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1526,7 +1726,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/String-0.5.0/Source/String.swift" /* String.swift in Sources */,
+				"__src_cc_ref_Packages/String-0.5.1/Source/String.swift" /* String.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1534,7 +1734,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
-				"__src_cc_ref_Packages/StructuredData-0.5.0/Sources/StructuredData.swift" /* StructuredData.swift in Sources */,
+				"__src_cc_ref_Packages/StructuredData-0.6.0/Sources/StructuredData.swift" /* StructuredData.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1631,62 +1831,72 @@
 		__Dependency_C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_C7" /* C7 */;
-			targetProxy = 805D801C1CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097611CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_CryptoEssentials /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_CryptoEssentials" /* CryptoEssentials */;
-			targetProxy = 805D801F1CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097661CD4D57D0061FA2D /* PBXContainerItemProxy */;
+		};
+		__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "______Target_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */;
+			targetProxy = 3A9097641CD4D57D0061FA2D /* PBXContainerItemProxy */;
+		};
+		__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = "______Target_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */;
+			targetProxy = 3A9097651CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_HMAC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_HMAC" /* HMAC */;
-			targetProxy = 805D80211CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097681CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_Hummingbird /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Hummingbird" /* Hummingbird */;
-			targetProxy = 805D80221CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097691CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_JSON /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_JSON" /* JSON */;
-			targetProxy = 805D80231CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A90976A1CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_S4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_S4" /* S4 */;
-			targetProxy = 805D80251CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A90976C1CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_SHA2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_SHA2" /* SHA2 */;
-			targetProxy = 805D80201CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097671CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_Strand /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Strand" /* Strand */;
-			targetProxy = 805D801E1CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097631CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_String /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_String" /* String */;
-			targetProxy = 805D80241CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A90976B1CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_StructuredData /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_StructuredData" /* StructuredData */;
-			targetProxy = 805D801D1CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A9097621CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_Vapor /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Vapor" /* Vapor */;
-			targetProxy = 805D80261CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A90976D1CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 		__Dependency_libc /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_libc" /* libc */;
-			targetProxy = 805D80271CC9AE2C003B9A5C /* PBXContainerItemProxy */;
+			targetProxy = 3A90976E1CD4D57D0061FA2D /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1719,6 +1929,38 @@
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_MODULE_NAME = CryptoEssentials;
+				PRODUCT_NAME = "lib$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		_ReleaseConf_CryptoEssentialsSwift2 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_INSTALL_NAME_BASE = "$(CONFIGURATION_BUILD_DIR)";
+				ENABLE_TESTABILITY = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_MODULE_NAME = CryptoEssentialsSwift2;
+				PRODUCT_NAME = "lib$(TARGET_NAME)";
+			};
+			name = Release;
+		};
+		_ReleaseConf_CryptoEssentialsSwift3 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_INSTALL_NAME_BASE = "$(CONFIGURATION_BUILD_DIR)";
+				ENABLE_TESTABILITY = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_MODULE_NAME = CryptoEssentialsSwift3;
 				PRODUCT_NAME = "lib$(TARGET_NAME)";
 			};
 			name = Release;
@@ -1975,6 +2217,40 @@
 				OTHER_LDFLAGS = "";
 				OTHER_SWIFT_FLAGS = "-DXcode";
 				PRODUCT_MODULE_NAME = CryptoEssentials;
+				PRODUCT_NAME = "lib$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		"___DebugConf_CryptoEssentialsSwift2" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_INSTALL_NAME_BASE = "$(CONFIGURATION_BUILD_DIR)";
+				ENABLE_TESTABILITY = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_MODULE_NAME = CryptoEssentialsSwift2;
+				PRODUCT_NAME = "lib$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		"___DebugConf_CryptoEssentialsSwift3" /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				DYLIB_INSTALL_NAME_BASE = "$(CONFIGURATION_BUILD_DIR)";
+				ENABLE_TESTABILITY = YES;
+				LD_RUNPATH_SEARCH_PATHS = "$(TOOLCHAIN_DIR)/usr/lib/swift/macosx";
+				MACOSX_DEPLOYMENT_TARGET = 10.10;
+				OTHER_CFLAGS = "";
+				OTHER_LDFLAGS = "";
+				OTHER_SWIFT_FLAGS = "-DXcode";
+				PRODUCT_MODULE_NAME = CryptoEssentialsSwift3;
 				PRODUCT_NAME = "lib$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -2255,6 +2531,24 @@
 			buildConfigurations = (
 				"___DebugConf_CryptoEssentials" /* Debug */,
 				_ReleaseConf_CryptoEssentials /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		"_______Confs_CryptoEssentialsSwift2" /* Build configuration list for PBXNativeTarget "CryptoEssentialsSwift2" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"___DebugConf_CryptoEssentialsSwift2" /* Debug */,
+				_ReleaseConf_CryptoEssentialsSwift2 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		"_______Confs_CryptoEssentialsSwift3" /* Build configuration list for PBXNativeTarget "CryptoEssentialsSwift3" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				"___DebugConf_CryptoEssentialsSwift3" /* Debug */,
+				_ReleaseConf_CryptoEssentialsSwift3 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/Vapor.xcodeproj/project.pbxproj
+++ b/Vapor.xcodeproj/project.pbxproj
@@ -7,85 +7,85 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		3A9097121CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097131CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097141CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097151CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097161CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A9097171CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A9097181CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097191CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A90971A1CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A90971B1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A90971C1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A90971D1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A90971E1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A90971F1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097201CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		3A9097211CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		3A9097221CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		3A9097231CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		3A9097241CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		3A9097251CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		3A9097261CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
-		3A9097271CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A9097281CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097291CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A90972A1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A90972B1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A90972C1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A90972D1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		3A90972E1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		3A90972F1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		3A9097301CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		3A9097311CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		3A9097321CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		3A9097331CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A9097341CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097351CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A9097361CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A9097371CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A9097381CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097391CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A90973A1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A90973B1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A90973C1CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A90973D1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A90973E1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A90973F1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		3A9097401CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		3A9097411CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		3A9097421CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		3A9097431CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		3A9097441CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		3A9097451CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A9097461CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097471CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A9097481CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A9097491CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A90974A1CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A90974B1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		3A90974C1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		3A90974D1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		3A90974E1CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		3A90974F1CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		3A9097501CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		3A9097511CD4D5790061FA2D /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
-		3A9097521CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
-		3A9097531CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
-		3A9097541CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
-		3A9097551CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
-		3A9097561CD4D5790061FA2D /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
-		3A9097571CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
-		3A9097581CD4D5790061FA2D /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
-		3A9097591CD4D5790061FA2D /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
-		3A90975A1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
-		3A90975B1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
-		3A90975C1CD4D5790061FA2D /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
-		3A90975D1CD4D5790061FA2D /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
-		3A90975E1CD4D5790061FA2D /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
-		3A90975F1CD4D5790061FA2D /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
-		3A9097601CD4D5790061FA2D /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A99205A1CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A99205B1CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A99205C1CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A99205D1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A99205E1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A99205F1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9920601CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9920611CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9920621CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9920631CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9920641CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9920651CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9920661CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920671CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920681CD60F3B001633AD /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9920691CD60F3B001633AD /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A99206A1CD60F3B001633AD /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A99206B1CD60F3B001633AD /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A99206C1CD60F3B001633AD /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A99206D1CD60F3B001633AD /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A99206E1CD60F3B001633AD /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A99206F1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9920701CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9920711CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9920721CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9920731CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920741CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920751CD60F3B001633AD /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9920761CD60F3B001633AD /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9920771CD60F3B001633AD /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9920781CD60F3B001633AD /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9920791CD60F3B001633AD /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A99207A1CD60F3B001633AD /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A99207B1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A99207C1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A99207D1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A99207E1CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A99207F1CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920801CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920811CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A9920821CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A9920831CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9920841CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9920851CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920861CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920871CD60F3B001633AD /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9920881CD60F3B001633AD /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9920891CD60F3B001633AD /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A99208A1CD60F3B001633AD /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A99208B1CD60F3B001633AD /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A99208C1CD60F3B001633AD /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A99208D1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A99208E1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A99208F1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A9920901CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A9920911CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920921CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920931CD60F3B001633AD /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9920941CD60F3B001633AD /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9920951CD60F3B001633AD /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9920961CD60F3B001633AD /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9920971CD60F3B001633AD /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9920981CD60F3B001633AD /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9920991CD60F3B001633AD /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
+		3A99209A1CD60F3B001633AD /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
+		3A99209B1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
+		3A99209C1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
+		3A99209D1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift3" /* libCryptoEssentialsSwift3.dylib */; };
+		3A99209E1CD60F3B001633AD /* libStrand.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Strand" /* libStrand.dylib */; };
+		3A99209F1CD60F3B001633AD /* libStructuredData.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_StructuredData" /* libStructuredData.dylib */; };
+		3A9920A01CD60F3B001633AD /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
+		3A9920A11CD60F3B001633AD /* libSHA2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_SHA2" /* libSHA2.dylib */; };
+		3A9920A21CD60F3B001633AD /* libHMAC.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_HMAC" /* libHMAC.dylib */; };
+		3A9920A31CD60F3B001633AD /* libHummingbird.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Hummingbird" /* libHummingbird.dylib */; };
+		3A9920A41CD60F3B001633AD /* libJSON.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_JSON" /* libJSON.dylib */; };
+		3A9920A51CD60F3B001633AD /* libString.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_String" /* libString.dylib */; };
+		3A9920A61CD60F3B001633AD /* libS4.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_S4" /* libS4.dylib */; };
+		3A9920A71CD60F3B001633AD /* libVapor.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_Vapor" /* libVapor.dylib */; };
+		3A9920A81CD60F3B001633AD /* liblibc.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_libc" /* liblibc.dylib */; };
 		_LinkFileRef_C7 /* libC7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_C7" /* libC7.dylib */; };
 		_LinkFileRef_CryptoEssentials /* libCryptoEssentials.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentials" /* libCryptoEssentials.dylib */; };
 		_LinkFileRef_CryptoEssentialsSwift2 /* libCryptoEssentialsSwift2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = "_____Product_CryptoEssentialsSwift2" /* libCryptoEssentialsSwift2.dylib */; };
@@ -253,98 +253,98 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		3A9097611CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920A91CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_C7";
 			remoteInfo = C7;
 		};
-		3A9097621CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AA1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_StructuredData";
 			remoteInfo = StructuredData;
 		};
-		3A9097631CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AB1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Strand";
 			remoteInfo = Strand;
 		};
-		3A9097641CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AC1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_CryptoEssentialsSwift2";
 			remoteInfo = CryptoEssentialsSwift2;
 		};
-		3A9097651CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AD1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_CryptoEssentialsSwift3";
 			remoteInfo = CryptoEssentialsSwift3;
 		};
-		3A9097661CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AE1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_CryptoEssentials";
 			remoteInfo = CryptoEssentials;
 		};
-		3A9097671CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920AF1CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_SHA2";
 			remoteInfo = SHA2;
 		};
-		3A9097681CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B01CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_HMAC";
 			remoteInfo = HMAC;
 		};
-		3A9097691CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B11CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Hummingbird";
 			remoteInfo = Hummingbird;
 		};
-		3A90976A1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B21CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_JSON";
 			remoteInfo = JSON;
 		};
-		3A90976B1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B31CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_String";
 			remoteInfo = String;
 		};
-		3A90976C1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B41CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_S4";
 			remoteInfo = S4;
 		};
-		3A90976D1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B51CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = "______Target_Vapor";
 			remoteInfo = Vapor;
 		};
-		3A90976E1CD4D57D0061FA2D /* PBXContainerItemProxy */ = {
+		3A9920B61CD60F3E001633AD /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = __RootObject_ /* Project object */;
 			proxyType = 1;
@@ -560,20 +560,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A90971A1CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A90971B1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A90971C1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A90971D1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A90971E1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A90971F1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
-				3A9097201CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
-				3A9097211CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
-				3A9097221CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
-				3A9097231CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
-				3A9097241CD4D5790061FA2D /* libString.dylib in Frameworks */,
-				3A9097251CD4D5790061FA2D /* libS4.dylib in Frameworks */,
+				3A9920621CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A9920631CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9920641CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9920651CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A9920661CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920671CD60F3B001633AD /* libC7.dylib in Frameworks */,
+				3A9920681CD60F3B001633AD /* libSHA2.dylib in Frameworks */,
+				3A9920691CD60F3B001633AD /* libHMAC.dylib in Frameworks */,
+				3A99206A1CD60F3B001633AD /* libHummingbird.dylib in Frameworks */,
+				3A99206B1CD60F3B001633AD /* libJSON.dylib in Frameworks */,
+				3A99206C1CD60F3B001633AD /* libString.dylib in Frameworks */,
+				3A99206D1CD60F3B001633AD /* libS4.dylib in Frameworks */,
 				_LinkFileRef_Vapor /* libVapor.dylib in Frameworks */,
-				3A9097261CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
+				3A99206E1CD60F3B001633AD /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -581,18 +581,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097391CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A90973A1CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A90973B1CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A90973C1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A90973D1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A90973E1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
-				3A90973F1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
-				3A9097401CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
-				3A9097411CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
-				3A9097421CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
-				3A9097431CD4D5790061FA2D /* libString.dylib in Frameworks */,
-				3A9097441CD4D5790061FA2D /* libS4.dylib in Frameworks */,
+				3A9920811CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A9920821CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9920831CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9920841CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A9920851CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920861CD60F3B001633AD /* libC7.dylib in Frameworks */,
+				3A9920871CD60F3B001633AD /* libSHA2.dylib in Frameworks */,
+				3A9920881CD60F3B001633AD /* libHMAC.dylib in Frameworks */,
+				3A9920891CD60F3B001633AD /* libHummingbird.dylib in Frameworks */,
+				3A99208A1CD60F3B001633AD /* libJSON.dylib in Frameworks */,
+				3A99208B1CD60F3B001633AD /* libString.dylib in Frameworks */,
+				3A99208C1CD60F3B001633AD /* libS4.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -601,8 +601,8 @@
 			buildActionMask = 0;
 			files = (
 				_LinkFileRef_CryptoEssentials /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097151CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097161CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A99205D1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A99205E1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -610,7 +610,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097141CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A99205C1CD60F3B001633AD /* libC7.dylib in Frameworks */,
 				_LinkFileRef_Strand /* libStrand.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -619,7 +619,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097131CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A99205B1CD60F3B001633AD /* libC7.dylib in Frameworks */,
 				_LinkFileRef_StructuredData /* libStructuredData.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -628,20 +628,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097451CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097461CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097471CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A9097481CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A9097491CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A90974A1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
-				3A90974B1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
-				3A90974C1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
-				3A90974D1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
-				3A90974E1CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
-				3A90974F1CD4D5790061FA2D /* libString.dylib in Frameworks */,
-				3A9097501CD4D5790061FA2D /* libS4.dylib in Frameworks */,
-				3A9097511CD4D5790061FA2D /* libVapor.dylib in Frameworks */,
-				3A9097521CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
+				3A99208D1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A99208E1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A99208F1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9920901CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A9920911CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920921CD60F3B001633AD /* libC7.dylib in Frameworks */,
+				3A9920931CD60F3B001633AD /* libSHA2.dylib in Frameworks */,
+				3A9920941CD60F3B001633AD /* libHMAC.dylib in Frameworks */,
+				3A9920951CD60F3B001633AD /* libHummingbird.dylib in Frameworks */,
+				3A9920961CD60F3B001633AD /* libJSON.dylib in Frameworks */,
+				3A9920971CD60F3B001633AD /* libString.dylib in Frameworks */,
+				3A9920981CD60F3B001633AD /* libS4.dylib in Frameworks */,
+				3A9920991CD60F3B001633AD /* libVapor.dylib in Frameworks */,
+				3A99209A1CD60F3B001633AD /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -657,9 +657,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097171CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097181CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097191CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A99205F1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A9920601CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9920611CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -681,7 +681,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097121CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A99205A1CD60F3B001633AD /* libC7.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -689,18 +689,18 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097271CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097281CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097291CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A90972A1CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A90972B1CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A90972C1CD4D5790061FA2D /* libC7.dylib in Frameworks */,
-				3A90972D1CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
-				3A90972E1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
-				3A90972F1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
-				3A9097301CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
-				3A9097311CD4D5790061FA2D /* libString.dylib in Frameworks */,
-				3A9097321CD4D5790061FA2D /* libS4.dylib in Frameworks */,
+				3A99206F1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A9920701CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A9920711CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A9920721CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A9920731CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920741CD60F3B001633AD /* libC7.dylib in Frameworks */,
+				3A9920751CD60F3B001633AD /* libSHA2.dylib in Frameworks */,
+				3A9920761CD60F3B001633AD /* libHMAC.dylib in Frameworks */,
+				3A9920771CD60F3B001633AD /* libHummingbird.dylib in Frameworks */,
+				3A9920781CD60F3B001633AD /* libJSON.dylib in Frameworks */,
+				3A9920791CD60F3B001633AD /* libString.dylib in Frameworks */,
+				3A99207A1CD60F3B001633AD /* libS4.dylib in Frameworks */,
 				_LinkFileRef_libc /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -709,20 +709,20 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097531CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097541CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097551CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A9097561CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A9097571CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A9097581CD4D5790061FA2D /* libC7.dylib in Frameworks */,
-				3A9097591CD4D5790061FA2D /* libSHA2.dylib in Frameworks */,
-				3A90975A1CD4D5790061FA2D /* libHMAC.dylib in Frameworks */,
-				3A90975B1CD4D5790061FA2D /* libHummingbird.dylib in Frameworks */,
-				3A90975C1CD4D5790061FA2D /* libJSON.dylib in Frameworks */,
-				3A90975D1CD4D5790061FA2D /* libString.dylib in Frameworks */,
-				3A90975E1CD4D5790061FA2D /* libS4.dylib in Frameworks */,
-				3A90975F1CD4D5790061FA2D /* libVapor.dylib in Frameworks */,
-				3A9097601CD4D5790061FA2D /* liblibc.dylib in Frameworks */,
+				3A99209B1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A99209C1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A99209D1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A99209E1CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A99209F1CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920A01CD60F3B001633AD /* libC7.dylib in Frameworks */,
+				3A9920A11CD60F3B001633AD /* libSHA2.dylib in Frameworks */,
+				3A9920A21CD60F3B001633AD /* libHMAC.dylib in Frameworks */,
+				3A9920A31CD60F3B001633AD /* libHummingbird.dylib in Frameworks */,
+				3A9920A41CD60F3B001633AD /* libJSON.dylib in Frameworks */,
+				3A9920A51CD60F3B001633AD /* libString.dylib in Frameworks */,
+				3A9920A61CD60F3B001633AD /* libS4.dylib in Frameworks */,
+				3A9920A71CD60F3B001633AD /* libVapor.dylib in Frameworks */,
+				3A9920A81CD60F3B001633AD /* liblibc.dylib in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -730,12 +730,12 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 0;
 			files = (
-				3A9097331CD4D5790061FA2D /* libCryptoEssentials.dylib in Frameworks */,
-				3A9097341CD4D5790061FA2D /* libCryptoEssentialsSwift2.dylib in Frameworks */,
-				3A9097351CD4D5790061FA2D /* libCryptoEssentialsSwift3.dylib in Frameworks */,
-				3A9097361CD4D5790061FA2D /* libStrand.dylib in Frameworks */,
-				3A9097371CD4D5790061FA2D /* libStructuredData.dylib in Frameworks */,
-				3A9097381CD4D5790061FA2D /* libC7.dylib in Frameworks */,
+				3A99207B1CD60F3B001633AD /* libCryptoEssentials.dylib in Frameworks */,
+				3A99207C1CD60F3B001633AD /* libCryptoEssentialsSwift2.dylib in Frameworks */,
+				3A99207D1CD60F3B001633AD /* libCryptoEssentialsSwift3.dylib in Frameworks */,
+				3A99207E1CD60F3B001633AD /* libStrand.dylib in Frameworks */,
+				3A99207F1CD60F3B001633AD /* libStructuredData.dylib in Frameworks */,
+				3A9920801CD60F3B001633AD /* libC7.dylib in Frameworks */,
 				_LinkFileRef_SHA2 /* libSHA2.dylib in Frameworks */,
 				_LinkFileRef_HMAC /* libHMAC.dylib in Frameworks */,
 				_LinkFileRef_Hummingbird /* libHummingbird.dylib in Frameworks */,
@@ -1831,72 +1831,72 @@
 		__Dependency_C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_C7" /* C7 */;
-			targetProxy = 3A9097611CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920A91CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_CryptoEssentials /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_CryptoEssentials" /* CryptoEssentials */;
-			targetProxy = 3A9097661CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AE1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_CryptoEssentialsSwift2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_CryptoEssentialsSwift2" /* CryptoEssentialsSwift2 */;
-			targetProxy = 3A9097641CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AC1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_CryptoEssentialsSwift3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_CryptoEssentialsSwift3" /* CryptoEssentialsSwift3 */;
-			targetProxy = 3A9097651CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AD1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_HMAC /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_HMAC" /* HMAC */;
-			targetProxy = 3A9097681CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B01CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_Hummingbird /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Hummingbird" /* Hummingbird */;
-			targetProxy = 3A9097691CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B11CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_JSON /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_JSON" /* JSON */;
-			targetProxy = 3A90976A1CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B21CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_S4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_S4" /* S4 */;
-			targetProxy = 3A90976C1CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B41CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_SHA2 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_SHA2" /* SHA2 */;
-			targetProxy = 3A9097671CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AF1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_Strand /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Strand" /* Strand */;
-			targetProxy = 3A9097631CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AB1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_String /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_String" /* String */;
-			targetProxy = 3A90976B1CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B31CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_StructuredData /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_StructuredData" /* StructuredData */;
-			targetProxy = 3A9097621CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920AA1CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_Vapor /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_Vapor" /* Vapor */;
-			targetProxy = 3A90976D1CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B51CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 		__Dependency_libc /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = "______Target_libc" /* libc */;
-			targetProxy = 3A90976E1CD4D57D0061FA2D /* PBXContainerItemProxy */;
+			targetProxy = 3A9920B61CD60F3E001633AD /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/Vapor.xcodeproj/xcshareddata/xcschemes/Vapor.xcscheme
+++ b/Vapor.xcodeproj/xcshareddata/xcschemes/Vapor.xcscheme
@@ -126,6 +126,34 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "______Target_CryptoEssentialsSwift2"
+               BuildableName = "libCryptoEssentialsSwift2.dylib"
+               BlueprintName = "CryptoEssentialsSwift2"
+               ReferencedContainer = "container:Vapor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "______Target_CryptoEssentialsSwift3"
+               BuildableName = "libCryptoEssentialsSwift3.dylib"
+               BlueprintName = "CryptoEssentialsSwift3"
+               ReferencedContainer = "container:Vapor.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "______Target_HMAC"
                BuildableName = "libHMAC.dylib"
                BlueprintName = "HMAC"


### PR DESCRIPTION
So I had to fix the Json issue by making `Json` conform to `JsonRepresentable` and had to wrap nested containers with `Json` as well. Until it's possible to express a specific array type to conform to a new protocol, we'll have to go from

```
[
    "hello": [1, "world"]
]
```

```
[
    "hello": Json([1, "world"])
]
```

Not ideal, but I can't find a better way for now. Let me know if you know how to improve it.