### PR TITLE
hound updates

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,3 +6,4 @@ excluded:
   - Packages
   - Sources/Vapor/Core/Generated.swift
   - Sources/Generator
+

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,6 @@
 disabled_rules:
+  - line_length
 opt_in_rules:
-  - missing_docs
 included:
 excluded:
   - Packages


### PR DESCRIPTION
Hound doesn't like the way we format our docs

Example:
```
/**
    Stuff here
*/
```

It also doesn't like lines that are too long which is annoying.

These updates should make it easier to deal with.