### PR TITLE
session token fix

### DIFF
--- a/Sources/Vapor/Session/MemorySessionDriver.swift
+++ b/Sources/Vapor/Session/MemorySessionDriver.swift
@@ -16,7 +16,7 @@ public class MemorySessionDriver: SessionDriver {
 
     /**
         Loads value for session id at given key
-     */
+    */
     public func valueFor(key: String, identifier: String) -> String? {
         var value: String?
         sessionsLock.locked {
@@ -28,7 +28,7 @@ public class MemorySessionDriver: SessionDriver {
 
     /**
         Sets value for session id at given key
-     */
+    */
     public func set(_ value: String?, forKey key: String, identifier: String) {
         sessionsLock.locked {
             if sessions[identifier] == nil {
@@ -40,8 +40,15 @@ public class MemorySessionDriver: SessionDriver {
     }
 
     /**
+        Returns true if the identifier is in use.
+    */
+    public func contains(identifier: String) -> Bool {
+        return sessions[identifier] != nil
+    }
+
+    /**
         Create new unique session id
-     */
+    */
     public func makeSessionIdentifier() -> String {
         var identifier = String(time(nil))
         identifier += "v@p0r"
@@ -54,8 +61,8 @@ public class MemorySessionDriver: SessionDriver {
     }
 
     /**
-     Destroys session with associated identifier
-     */
+        Destroys session with associated identifier
+    */
     public func destroy(_ identifier: String) {
         sessionsLock.locked {
             sessions[identifier] = nil

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -21,11 +21,19 @@ public protocol SessionDriver: class {
     func valueFor(key: String, identifier: String) -> String?
 
     /**
+        Returns true if the session driver
+        contains an entry for the given identifier.
+     
+        - parameter identifier: the identifier of the session
+    */
+    func contains(identifier: String) -> Bool
+
+    /**
         Set a alue for the given key associated with a session of the given identifier
 
         - parameter value: value to set, nil if should remove
         - parameter key: key to set
-        - parameter identifier: identifier of session
+        - parameter identifier: identifier of the session
      */
     func set(_ value: String?, forKey key: String, identifier: String)
 

--- a/Sources/Vapor/Session/SessionDriver.swift
+++ b/Sources/Vapor/Session/SessionDriver.swift
@@ -23,7 +23,7 @@ public protocol SessionDriver: class {
     /**
         Returns true if the session driver
         contains an entry for the given identifier.
-     
+
         - parameter identifier: the identifier of the session
     */
     func contains(identifier: String) -> Bool

--- a/Sources/Vapor/Session/SessionMiddleware.swift
+++ b/Sources/Vapor/Session/SessionMiddleware.swift
@@ -17,7 +17,10 @@ class SessionMiddleware: Middleware {
     func respond(to request: Request, chainingTo chain: Responder) throws -> Response {
         var request = request
 
-        if let sessionIdentifier = request.cookies["vapor-session"] {
+        if
+            let sessionIdentifier = request.cookies["vapor-session"]
+            where driver.contains(identifier: sessionIdentifier)
+        {
             request.session = Session(identifier: sessionIdentifier, driver: driver)
         } else {
             request.session = Session(driver: driver)

--- a/Tests/Vapor/SessionTests.swift
+++ b/Tests/Vapor/SessionTests.swift
@@ -14,7 +14,8 @@ class SessionTests: XCTestCase {
         return [
            ("testDestroy_asksDriverToDestroy", testDestroy_asksDriverToDestroy),
            ("testSubscriptGet_asksDriverForValue", testSubscriptGet_asksDriverForValue),
-           ("testSubscriptSet_asksDriverToSetValue", testSubscriptSet_asksDriverToSetValue)
+           ("testSubscriptSet_asksDriverToSetValue", testSubscriptSet_asksDriverToSetValue),
+           ("testIdentifierCreation", testIdentifierCreation)
         ]
     }
 

--- a/Tests/Vapor/SessionTests.swift
+++ b/Tests/Vapor/SessionTests.swift
@@ -54,6 +54,42 @@ class SessionTests: XCTestCase {
         XCTAssertEqual(key.value, "bar")
         XCTAssertEqual(key.key, "foo")
     }
+
+    func testIdentifierCreation() {
+        let app = Application()
+
+        app.get("cookie") { request in
+            request.session?["hi"] = "test"
+            return "hi"
+        }
+
+        app.bootRoutes()
+
+        var request = Request(method: .get, path: "cookie")
+        request.headers["Cookie"] = "vapor-session=123"
+
+        guard let response = try? app.respond(to: request) else {
+            XCTFail("Could not get response")
+            return
+        }
+
+        var sessionMiddleware: SessionMiddleware?
+
+        for middleware in app.middleware {
+            if let middleware = middleware as? SessionMiddleware {
+                sessionMiddleware = middleware
+            }
+        }
+
+        XCTAssert(sessionMiddleware != nil, "Could not find session middleware")
+
+        XCTAssert(sessionMiddleware?.driver.contains(identifier: "123") == false, "Session should not contain 123")
+
+        XCTAssert(response.cookies["vapor-session"] != nil, "No cookie was added")
+
+        let id = response.cookies["vapor-session"] ?? ""
+        XCTAssert(sessionMiddleware?.driver.contains(identifier: id) == true, "Session did not contain cookie")
+    }
 }
 
 private class TestDriver: SessionDriver {
@@ -74,6 +110,10 @@ private class TestDriver: SessionDriver {
     func valueFor(key: String, identifier: String) -> String? {
         actions.append(.ValueFor(key: key, identifier: identifier))
         return nil
+    }
+
+    private func contains(identifier: String) -> Bool {
+        return false
     }
 
     func set(_ value: String?, forKey key: String, identifier: String) {


### PR DESCRIPTION
Currently, session tokens are only generated if no session token was provided. This allows for unused session tokens passed by the client, such as `"abc"`, to be used.

This PR enforces session token generation by the session driver. 

It does this by adding a method to the `SessionDriver` protocol `contains(identifier: String) -> Bool` and checking in the middleware if the given identifier is in the driver before opening the session.

Fixes #193 