### PR TITLE
cli git additions

### DIFF
--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -2,7 +2,7 @@ import libc
 import MediaType
 
 public class Application {
-    public static let VERSION = "0.5.3"
+    public static let VERSION = "0.8.0"
 
     /**
         The router driver is responsible

--- a/vapor
+++ b/vapor
@@ -8,10 +8,10 @@
 
 class Vapor {
     var arguments: [String]
-    
+
     var release = false
     var swift2 = false
-    
+
     var flags: [String]
 
     init(arguments: [String]) {
@@ -19,7 +19,7 @@ class Vapor {
         var flags: [String] = []
 
         for argument in arguments {
-            if argument.characters.first == "-"  {
+            if argument.characters.first == "-" {
                 if argument == "--release" {
                     release = true
                 } else if argument == "--swift2.2" {
@@ -28,7 +28,7 @@ class Vapor {
                     flags.append(argument)
                 }
             } else {
-                commands.append(argument)        
+                commands.append(argument)
             }
         }
 
@@ -116,7 +116,7 @@ class Vapor {
         run("rm -rf Packages .build", orFail: "Could not clean")
         print("Cleaned.")
     }
-    
+
     func build() {
         if swift2 {
             buildSwift2()
@@ -124,7 +124,7 @@ class Vapor {
             buildSwift3()
         }
     }
-    
+
     func buildSwift3() {
         do {
             var buildFlags = ""
@@ -159,8 +159,8 @@ class Vapor {
             let lib = "/usr/local/opt/vapor/lib/"
             let rpath = ""
         #endif
-        
-        var cflags = ""        
+
+        var cflags = ""
         if release {
             cflags = "-O"
         }
@@ -191,23 +191,23 @@ class Vapor {
         print("Running...")
         do {
 
-            
+
             if swift2 {
                 try run(".build/VaporApp")
             } else {
                 var name = "App"
                 let folder = release ? "release" : "debug"
-                
+
                 #if swift(>=3.0)
                     let args = flags.joined(separator: " ")
                 #else
                     let args = flags.joinWithSeparator(" ")
                 #endif
-                
+
                 if arguments.count >= 3 {
                     name = arguments[2]
                 }
-                
+
                 try run(".build/\(folder)/\(name) \(args)")
             }
         } catch Error.System(let result) {

--- a/vapor
+++ b/vapor
@@ -11,6 +11,7 @@ class Vapor {
 
     var release = false
     var swift2 = false
+    var withoutGit = false
 
     var flags: [String]
 
@@ -24,6 +25,8 @@ class Vapor {
                     release = true
                 } else if argument == "--swift2.2" {
                     swift2 = true
+                } else if argument == "--without-git" {
+                    withoutGit = true
                 } else {
                     flags.append(argument)
                 }
@@ -232,6 +235,11 @@ class Vapor {
             try run("curl -L https://github.com/qutheory/vapor-example/archive/master.tar.gz > \(escapedName)/vapor-example.tar.gz")
             try run("tar -xzf \(escapedName)/vapor-example.tar.gz --strip-components=1 --directory \(escapedName)")
             let _ = try? run("rm \(escapedName)/vapor-example.tar.gz")
+
+            if withoutGit == false {
+                try run("git init \(escapedName)")
+            }
+
             print()
             print("Project \"\(name)\" has been created.")
             print("Enjoy!")
@@ -252,6 +260,9 @@ class Vapor {
         print("  --swift2.2")
         print("    Builds and runs using Swift 2.2")
         print()
+        print("  --without-git")
+        print("    Skips initialization of an empty Git repository")
+        print()
         print("Options:")
         print("  build [file1, file2, ...]")
         print("    Builds source files and links Vapor libs.")
@@ -264,7 +275,8 @@ class Vapor {
         print()
         print("  new <project-name>")
         print("    Clones the Vapor Example to a given ")
-        print("    folder name and removes .git.")
+        print("    folder name and initializes an empty")
+        print("    Git repository inside it.")
         print()
         print("  clean")
         print()


### PR DESCRIPTION
`vapor new` now automatically initializes an empty Git repository in the newly created project. Added optional `--without-git` flag to prevent this behavior.

Closes #216.