### PR TITLE
POST request routing from resource()

### DIFF
--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -54,7 +54,7 @@ extension Application {
 
         //POST /entities
         self.post(path) { request in
-            return try controllerFactory().index(request)
+            return try controllerFactory().store(request)
         }
 
         //GET /entities/:id


### PR DESCRIPTION
Fixed routing of POST requests to Controllers added to Application with resource(). Previously both GET and POST were routing to `index()`, now POST routes to `store()`