### PR TITLE
Added a controller method to delete all instances

### DIFF
--- a/Sources/Development/Controllers/UserController.swift
+++ b/Sources/Development/Controllers/UserController.swift
@@ -47,11 +47,11 @@ class UserController: Controller {
     /**
      Modify an instance (only the fields that are present in the request)
      */
-    func modify(_ request:Request, item user: User) throws -> ResponseRepresentable {
+    func modify(_ request: Request, item user: User) throws -> ResponseRepresentable {
         //Testing JsonRepresentable
         return user.makeJson()
     }
-    
+
     /**
         Delete an instance.
      */

--- a/Sources/Development/Controllers/UserController.swift
+++ b/Sources/Development/Controllers/UserController.swift
@@ -44,7 +44,14 @@ class UserController: Controller {
         return user.makeJson()
     }
 
-
+    /**
+     Modify an instance (only the fields that are present in the request)
+     */
+    func modify(_ request:Request, item user: User) throws -> ResponseRepresentable {
+        //Testing JsonRepresentable
+        return user.makeJson()
+    }
+    
     /**
         Delete an instance.
      */

--- a/Sources/Development/Controllers/UserController.swift
+++ b/Sources/Development/Controllers/UserController.swift
@@ -53,4 +53,12 @@ class UserController: Controller {
         return user
     }
 
+    /**
+        Delete all instances.
+     */
+    func destroyAll(_ request: Request) throws -> ResponseRepresentable {
+        return Json([
+            "controller": "MyController.destroyAll"
+        ])
+    }
 }

--- a/Sources/Development/Controllers/UserController.swift
+++ b/Sources/Development/Controllers/UserController.swift
@@ -64,7 +64,7 @@ class UserController: Controller {
         Delete all instances.
      */
     func destroyAll(_ request: Request) throws -> ResponseRepresentable {
-        return Json([
+        return JSON([
             "controller": "MyController.destroyAll"
         ])
     }

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -1,3 +1,5 @@
+import S4
+
 /**
     Any type that conforms to this protocol
     can be passed as a requirement to Vapor's
@@ -77,6 +79,17 @@ extension Application {
             return try controllerFactory().destroy(request, item: item)
         }
 
+        self.options(path) { request in
+            let headers:Headers = ["Allow":"GET,POST,DELETE,OPTIONS"]
+            let response = Response(status: .ok, headers: headers, body: Data())
+            return response
+        }
+        
+        self.options(path, Resource.Item.self) { request, item in
+            let headers:Headers = ["Allow":"GET,POST,PUT,DELETE,OPTIONS"]
+            let response = Response(status: .ok, headers: headers, body: Data())
+            return response
+        }
     }
 
     /**

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -79,7 +79,7 @@ extension Application {
             return try controllerFactory().destroy(request, item: item)
         }
 
-        //PATH /entities/:id
+        //PATCH /entities/:id
         self.patch(path, Resource.Item.self) { request, item in
             return try controllerFactory().modify(request, item:item)
         }

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -85,13 +85,19 @@ extension Application {
         }
 
         self.options(path) { request in
-            let headers:Headers = ["Allow":"GET,POST,DELETE,OPTIONS"]
+            let headers:Headers = [
+                "Allow":"GET,POST,DELETE,OPTIONS",
+                "Content-Type":"text/plain"
+            ]
             let response = Response(status: .ok, headers: headers, body: Data())
             return response
         }
         
         self.options(path, Resource.Item.self) { request, item in
-            let headers:Headers = ["Allow":"GET,POST,PUT,PATCH,DELETE,OPTIONS"]
+            let headers:Headers = [
+                "Allow":"GET,POST,PUT,PATCH,DELETE,OPTIONS",
+                "Content-Type":"text/plain"
+            ]
             let response = Response(status: .ok, headers: headers, body: Data())
             return response
         }

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -67,7 +67,12 @@ extension Application {
             return try controllerFactory().update(request, item: item)
         }
 
-        //DELETE /intities/:id
+        //DELETE /entities
+        self.delete(path) { request in
+            return try controllerFactory().destroyAll(request)
+        }
+
+        //DELETE /entities/:id
         self.delete(path, Resource.Item.self) { request, item in
             return try controllerFactory().destroy(request, item: item)
         }

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -78,23 +78,23 @@ extension Application {
         self.delete(path, Resource.Item.self) { request, item in
             return try controllerFactory().destroy(request, item: item)
         }
-        
+
         //PATH /entities/:id
         self.patch(path, Resource.Item.self) { request, item in
             return try controllerFactory().modify(request, item:item)
         }
 
         self.options(path) { request in
-            let headers:Headers = [
+            let headers: Headers = [
                 "Allow":"GET,POST,DELETE,OPTIONS",
                 "Content-Type":"text/plain"
             ]
             let response = Response(status: .ok, headers: headers, body: Data())
             return response
         }
-        
+
         self.options(path, Resource.Item.self) { request, item in
-            let headers:Headers = [
+            let headers: Headers = [
                 "Allow":"GET,POST,PUT,PATCH,DELETE,OPTIONS",
                 "Content-Type":"text/plain"
             ]

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -78,6 +78,11 @@ extension Application {
         self.delete(path, Resource.Item.self) { request, item in
             return try controllerFactory().destroy(request, item: item)
         }
+        
+        //PATH /entities/:id
+        self.patch(path, Resource.Item.self) { request, item in
+            return try controllerFactory().modify(request, item:item)
+        }
 
         self.options(path) { request in
             let headers:Headers = ["Allow":"GET,POST,DELETE,OPTIONS"]
@@ -86,7 +91,7 @@ extension Application {
         }
         
         self.options(path, Resource.Item.self) { request, item in
-            let headers:Headers = ["Allow":"GET,POST,PUT,DELETE,OPTIONS"]
+            let headers:Headers = ["Allow":"GET,POST,PUT,PATCH,DELETE,OPTIONS"]
             let response = Response(status: .ok, headers: headers, body: Data())
             return response
         }

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -26,11 +26,11 @@ public protocol ResourceController {
         Update an instance.
      */
     func update(_ request: Request, item: Item) throws -> ResponseRepresentable
-    
+
     /**
         Modify an instance (only the fields that are present in the request)
      */
-    func modify(_ request:Request, item: Item) throws -> ResponseRepresentable
+    func modify(_ request: Request, item: Item) throws -> ResponseRepresentable
 
     /** 
         Delete an instance.

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -26,6 +26,11 @@ public protocol ResourceController {
         Update an instance.
      */
     func update(_ request: Request, item: Item) throws -> ResponseRepresentable
+    
+    /**
+        Modify an instance (only the fields that are present in the request)
+     */
+    func modify(_ request:Request, item: Item) throws -> ResponseRepresentable
 
     /** 
         Delete an instance.

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -31,7 +31,7 @@ public protocol ResourceController {
         Delete an instance.
      */
     func destroy(_ request: Request, item: Item) throws -> ResponseRepresentable
-    
+
     /**
         Delete all instances.
      */
@@ -74,7 +74,7 @@ extension ResourceController {
     public func destroy(_ request: Request, item: Item) throws -> ResponseRepresentable {
         throw Abort.notFound
     }
-    
+
     /**
         Delete all instances.
      */

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -31,6 +31,11 @@ public protocol ResourceController {
         Delete an instance.
      */
     func destroy(_ request: Request, item: Item) throws -> ResponseRepresentable
+    
+    /**
+        Delete all instances.
+     */
+    func destroyAll(_ request: Request) throws -> ResponseRepresentable
 }
 
 extension ResourceController {
@@ -67,6 +72,13 @@ extension ResourceController {
         Delete an instance.
      */
     public func destroy(_ request: Request, item: Item) throws -> ResponseRepresentable {
+        throw Abort.notFound
+    }
+    
+    /**
+        Delete all instances.
+     */
+    public func destroyAll(_ request: Request) throws -> ResponseRepresentable {
         throw Abort.notFound
     }
 }

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -74,6 +74,13 @@ extension ResourceController {
     }
 
     /**
+     Modify an instance (only the fields that are present in the request)
+     */
+    public func modify(_ request: Request, item: Item) throws -> ResponseRepresentable {
+        throw Abort.notFound
+    }
+
+    /**
         Delete an instance.
      */
     public func destroy(_ request: Request, item: Item) throws -> ResponseRepresentable {

--- a/Tests/Vapor/ControllerTests.swift
+++ b/Tests/Vapor/ControllerTests.swift
@@ -19,8 +19,9 @@ private class TestController: Controller {
         show: Int,
         update: Int,
         destroy: Int,
+        destroyAll: Int,
         hello: Int
-        ) = (0, 0, 0, 0, 0, 0)
+        ) = (0, 0, 0, 0, 0, 0, 0)
 
     /**
         Display many instances
@@ -59,6 +60,14 @@ private class TestController: Controller {
     func destroy(_ request: Request, item: String) throws -> ResponseRepresentable {
         TestController.lock.destroy += 1
         return "destroy"
+    }
+    
+    /**
+        Deletes all instances
+     */
+    func destroyAll(_ request: Request) throws -> ResponseRepresentable {
+        TestController.lock.destroyAll += 1
+        return "destroyAll"
     }
 
     func hello(_ request: Request) throws -> ResponseRepresentable {

--- a/Tests/Vapor/ControllerTests.swift
+++ b/Tests/Vapor/ControllerTests.swift
@@ -18,10 +18,11 @@ private class TestController: Controller {
         store: Int,
         show: Int,
         update: Int,
+        modify: Int,
         destroy: Int,
         destroyAll: Int,
         hello: Int
-        ) = (0, 0, 0, 0, 0, 0, 0)
+        ) = (0, 0, 0, 0, 0, 0, 0, 0)
 
     /**
         Display many instances
@@ -52,6 +53,14 @@ private class TestController: Controller {
     func update(_ request: Request, item: String) throws -> ResponseRepresentable {
         TestController.lock.update += 1
         return "update"
+    }
+
+    /**
+        Modify an instance (only the fields in the request).
+     */
+    func modify(_ request: Request, item: String) throws -> ResponseRepresentable {
+        TestController.lock.modify += 1
+        return "modify"
     }
 
     /**

--- a/Tests/Vapor/ControllerTests.swift
+++ b/Tests/Vapor/ControllerTests.swift
@@ -61,7 +61,7 @@ private class TestController: Controller {
         TestController.lock.destroy += 1
         return "destroy"
     }
-    
+
     /**
         Deletes all instances
      */


### PR DESCRIPTION
When you send a DELETE request on an API without specifying an ID, it should delete all instances of that resource. So I added a destroyAll method to ResourceController to handle that case. This is my first pull request so I hope I did the testing and everything right.