### PR TITLE
localization proposal

### DIFF
--- a/Sources/Development/Localization/default.json
+++ b/Sources/Development/Localization/default.json
@@ -1,0 +1,3 @@
+{
+    "welcome-text": "Welcome to Defaults"
+}

--- a/Sources/Development/Localization/en.json
+++ b/Sources/Development/Localization/en.json
@@ -1,0 +1,3 @@
+{
+    "welcome-text": "Welcome to Vapor"
+}

--- a/Sources/Development/Localization/es.json
+++ b/Sources/Development/Localization/es.json
@@ -1,0 +1,3 @@
+{
+    "welcome-text": "Bienvenidos a Vapor"
+}

--- a/Sources/Vapor/Config/Config.swift
+++ b/Sources/Vapor/Config/Config.swift
@@ -11,7 +11,6 @@ private struct PrioritizedDirectoryQueue {
     }
 }
 
-
 /**
     Parses and interprets configuration files
     included under Config in the working directory.

--- a/Sources/Vapor/Config/Config.swift
+++ b/Sources/Vapor/Config/Config.swift
@@ -1,42 +1,7 @@
 import PathIndexable
-import Foundation
-
-internal struct JsonFile {
-    let name: String
-    let json: JSON
-
-    private static let suffix = ".json"
-
-    init(name: String, json: JSON) {
-        if
-            let nameSequence = name.characters.split(separator: ".").first
-            where name.hasSuffix(JsonFile.suffix)
-        {
-            self.name = String(nameSequence)
-        } else {
-            self.name = name
-        }
-        self.json = json
-    }
-}
-
-internal struct JsonDirectory {
-    let name: String
-    let files: [JsonFile]
-
-    subscript(_ fileName: String, _ paths: [PathIndex]) -> JSON? {
-        return files
-            .lazy
-            .filter { file in
-                file.name == fileName
-            }
-            .flatMap { file in file.json[paths] }
-            .first
-    }
-}
 
 private struct PrioritizedDirectoryQueue {
-    let directories: [JsonDirectory]
+    let directories: [JSONDirectory]
 
     subscript(_ fileName: String, indexes: [PathIndex]) -> JSON? {
         return directories
@@ -46,108 +11,6 @@ private struct PrioritizedDirectoryQueue {
     }
 }
 
-extension FileManager {
-    internal static func loadDirectory(_ path: String) -> JsonDirectory? {
-        guard let directoryName = path.components(separatedBy: "/").last else {
-            return nil
-        }
-        guard let contents = try? FileManager.contentsOfDirectory(path) else {
-            return nil
-        }
-
-        var jsonFiles: [JsonFile] = []
-        for file in contents where file.hasSuffix(".json") {
-            guard let name = file.components(separatedBy: "/").last else {
-                continue
-            }
-            guard let json = try? loadJson(file) else {
-                continue
-            }
-
-            let jsonFile = JsonFile(name: name, json: json)
-            jsonFiles.append(jsonFile)
-        }
-
-        let directory = JsonDirectory(name: directoryName, files: jsonFiles)
-        return directory
-    }
-
-    private static func loadJson(_ path: String) throws -> JSON {
-        let bytes = try FileManager.readBytesFromFile(path)
-        return try JSON.deserialize(bytes)
-    }
-}
-
-extension Process {
-    private static func makeCLIConfig() -> JsonDirectory {
-        let configArgs = NSProcessInfo.processInfo().arguments.filter { $0.hasPrefix("--config:") }
-
-        // [FileName: Json]
-        var directory: [String: JSON] = [:]
-
-        for arg in configArgs {
-            guard let (key, value) = parseArgument(arg) else {
-                continue
-            }
-
-            guard let (file, path) = parseConfigKey(key) else {
-                continue
-            }
-
-            var js = directory[file] ?? .object([:])
-            js[path] = .string(value)
-            directory[file] = js
-        }
-
-        let jsonFiles = directory.map { fileName, json in JsonFile(name: fileName, json: json) }
-        let config = JsonDirectory(name: "cli", files: jsonFiles)
-        return config
-    }
-
-    private static func parseArgument(_ arg: String) -> (key: String, value: String)? {
-        let info = arg
-            .characters
-            .split(separator: "=",
-                   maxSplits: 1,
-                   omittingEmptySubsequences: true)
-            .map(String.init)
-
-        guard info.count == 2, let key = info.first, let value = info.last else {
-            Log.info("Unable to parse possible config argument: \(arg)")
-            return nil
-        }
-
-        return (key, value)
-    }
-
-    private static func parseConfigKey(_ key: String) -> (file: String, path: [PathIndex])? {
-        // --config:app.port
-        // expect [--config, app.port]
-        let paths = key
-            .characters
-            .split(separator: ":",
-                   maxSplits: 1,
-                   omittingEmptySubsequences: true)
-            .map(String.init)
-
-        guard
-            paths.count == 2,
-            var keyPaths = paths.last?.components(separatedBy: "."),
-            let fileName = keyPaths.first
-            // first argument is file name, subsequent args are actual path
-            //
-            where keyPaths.count > 1
-            else {
-                Log.info("Unable to parse possible config path: \(key)")
-                return nil
-            }
-
-        // first argument is file name, subsequent arguments are paths
-        keyPaths.remove(at: 0)
-
-        return (fileName, keyPaths.map { $0 as PathIndex })
-    }
-}
 
 /**
     Parses and interprets configuration files
@@ -189,9 +52,9 @@ public class Config {
         self.environment = environment
 
 
-        let files = configurations.map { name, json in return JsonFile(name: name, json: json) }
-        let seedDirectory = JsonDirectory(name: "seed-data", files: files)
-        var prioritizedDirectories: [JsonDirectory] = [seedDirectory]
+        let files = configurations.map { name, json in return JSONFile(name: name, json: json) }
+        let seedDirectory = JSONDirectory(name: "seed-data", files: files)
+        var prioritizedDirectories: [JSONDirectory] = [seedDirectory]
 
         // command line args passed w/ following syntax loaded first after seed
         // --config:app.port=9090

--- a/Sources/Vapor/Config/Process+Config.swift
+++ b/Sources/Vapor/Config/Process+Config.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+extension Process {
+    static func makeCLIConfig() -> JSONDirectory {
+        let configArgs = NSProcessInfo.processInfo().arguments.filter { $0.hasPrefix("--config:") }
+
+        // [FileName: Json]
+        var directory: [String: JSON] = [:]
+
+        for arg in configArgs {
+            guard let (key, value) = parseArgument(arg) else {
+                continue
+            }
+
+            guard let (file, path) = parseConfigKey(key) else {
+                continue
+            }
+
+            var js = directory[file] ?? .object([:])
+            js[path] = .string(value)
+            directory[file] = js
+        }
+
+        let jsonFiles = directory.map { fileName, json in JSONFile(name: fileName, json: json) }
+        let config = JSONDirectory(name: "cli", files: jsonFiles)
+        return config
+    }
+
+    static func parseArgument(_ arg: String) -> (key: String, value: String)? {
+        let info = arg
+            .characters
+            .split(separator: "=",
+                   maxSplits: 1,
+                   omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard info.count == 2, let key = info.first, let value = info.last else {
+            Log.info("Unable to parse possible config argument: \(arg)")
+            return nil
+        }
+
+        return (key, value)
+    }
+
+    static func parseConfigKey(_ key: String) -> (file: String, path: [PathIndex])? {
+        // --config:app.port
+        // expect [--config, app.port]
+        let paths = key
+            .characters
+            .split(separator: ":",
+                   maxSplits: 1,
+                   omittingEmptySubsequences: true)
+            .map(String.init)
+
+        guard
+            paths.count == 2,
+            var keyPaths = paths.last?.components(separatedBy: "."),
+            let fileName = keyPaths.first
+            // first argument is file name, subsequent args are actual path
+            //
+            where keyPaths.count > 1
+            else {
+                Log.info("Unable to parse possible config path: \(key)")
+                return nil
+        }
+
+        // first argument is file name, subsequent arguments are paths
+        keyPaths.remove(at: 0)
+        
+        return (fileName, keyPaths.map { $0 as PathIndex })
+    }
+}

--- a/Sources/Vapor/Core/Application.swift
+++ b/Sources/Vapor/Core/Application.swift
@@ -25,9 +25,14 @@ public class Application {
     public let session: SessionDriver
 
     /**
-        Provides access to config settings.
-    */
+     Provides access to config settings.
+     */
     public let config: Config
+
+    /**
+     Provides access to config settings.
+     */
+    public let localization: Localization
 
     /**
         Provides access to the underlying
@@ -96,6 +101,7 @@ public class Application {
         workDir overrideWorkDir: String? = nil,
         sessionDriver: SessionDriver? = nil,
         config overrideConfig: Config? = nil,
+        localization overrideLocalization: Localization? = nil,
         hash: Hash = Hash(),
         server: Server.Type = HTTPStreamServer<ServerSocket>.self,
         router: RouterDriver = BranchRouter()
@@ -108,6 +114,9 @@ public class Application {
             ?? Process.valueFor(argument: "workDir")
             ?? "./"
         self.workDir = workDir.finish("/")
+
+        let localization = overrideLocalization ?? Localization(workingDirectory: workDir)
+        self.localization = localization
 
         let config = overrideConfig ?? Config(workingDirectory: workDir)
         self.config = config

--- a/Sources/Vapor/JSON/JSONDirectory.swift
+++ b/Sources/Vapor/JSON/JSONDirectory.swift
@@ -1,0 +1,46 @@
+struct JSONDirectory {
+    let name: String
+    let files: [JSONFile]
+
+    subscript(_ fileName: String, _ paths: [PathIndex]) -> JSON? {
+        return files
+            .lazy
+            .filter { file in
+                file.name == fileName
+            }
+            .flatMap { file in file.json[paths] }
+            .first
+    }
+}
+
+extension FileManager {
+    internal static func loadDirectory(_ path: String) -> JSONDirectory? {
+        guard let directoryName = path.components(separatedBy: "/").last else {
+            return nil
+        }
+        guard let contents = try? FileManager.contentsOfDirectory(path) else {
+            return nil
+        }
+
+        var jsonFiles: [JSONFile] = []
+        for file in contents where file.hasSuffix(".json") {
+            guard let name = file.components(separatedBy: "/").last else {
+                continue
+            }
+            guard let json = try? loadJson(file) else {
+                continue
+            }
+
+            let jsonFile = JSONFile(name: name, json: json)
+            jsonFiles.append(jsonFile)
+        }
+
+        let directory = JSONDirectory(name: directoryName, files: jsonFiles)
+        return directory
+    }
+
+    private static func loadJson(_ path: String) throws -> JSON {
+        let bytes = try FileManager.readBytesFromFile(path)
+        return try JSON.deserialize(bytes)
+    }
+}

--- a/Sources/Vapor/JSON/JSONFile.swift
+++ b/Sources/Vapor/JSON/JSONFile.swift
@@ -1,0 +1,18 @@
+struct JSONFile {
+    let name: String
+    let json: JSON
+
+    private static let suffix = ".json"
+
+    init(name: String, json: JSON) {
+        if
+            let nameSequence = name.characters.split(separator: ".").first
+            where name.hasSuffix(JSONFile.suffix)
+        {
+            self.name = String(nameSequence)
+        } else {
+            self.name = name
+        }
+        self.json = json
+    }
+}

--- a/Sources/Vapor/Localization/Localization.swift
+++ b/Sources/Vapor/Localization/Localization.swift
@@ -3,13 +3,13 @@ import Foundation
 
 public class Localization {
     private let localizationDirectoryPath: String
-    private let localization: JsonDirectory
+    private let localization: JSONDirectory
 
     public init(workingDirectory: String = "./") {
         let configDirectory = workingDirectory.finish("/") + "Localization/"
         self.localizationDirectoryPath = configDirectory
         self.localization = FileManager.loadDirectory(configDirectory)
-            ?? JsonDirectory(name: "empty", files: [])
+            ?? JSONDirectory(name: "empty", files: [])
     }
 
     public subscript(_ languageCode: String, _ paths: PathIndex...) -> String {

--- a/Sources/Vapor/Localization/Localization.swift
+++ b/Sources/Vapor/Localization/Localization.swift
@@ -19,6 +19,6 @@ public class Localization {
     public subscript(_ languageCode: String, _ paths: [PathIndex]) -> String {
         return localization[languageCode, paths]?.string
             ?? localization["default", paths]?.string
-            ?? "not found" // TODO: Discuss message or ""
+            ?? paths.map { "\($0)" }.joined(separator: ".")
     }
 }

--- a/Sources/Vapor/Localization/Localization.swift
+++ b/Sources/Vapor/Localization/Localization.swift
@@ -1,0 +1,24 @@
+import PathIndexable
+import Foundation
+
+public class Localization {
+    private let localizationDirectoryPath: String
+    private let localization: JsonDirectory
+
+    public init(workingDirectory: String = "./") {
+        let configDirectory = workingDirectory.finish("/") + "Localization/"
+        self.localizationDirectoryPath = configDirectory
+        self.localization = FileManager.loadDirectory(configDirectory)
+            ?? JsonDirectory(name: "empty", files: [])
+    }
+
+    public subscript(_ languageCode: String, _ paths: PathIndex...) -> String {
+        return self[languageCode, paths]
+    }
+
+    public subscript(_ languageCode: String, _ paths: [PathIndex]) -> String {
+        return localization[languageCode, paths]?.string
+            ?? localization["default", paths]?.string
+            ?? "not found" // TODO: Discuss message or ""
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -11,7 +11,7 @@ XCTMain([
     testCase(EventTests.allTests),
     testCase(HashTests.allTests),
     testCase(HTTPStreamTests.allTests),
-    testCase(LocalizationTests.allTests)
+    testCase(LocalizationTests.allTests),
     testCase(LogTests.allTests),
     testCase(MemorySessionDriverTests.allTests),
     testCase(PerformanceTests.allTests),

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -23,7 +23,8 @@ XCTMain([
 	testCase(ValidationConvenienceTests.allTests),
 	testCase(ValidationCountTests.allTests),
 	testCase(ValidationTests.allTests),
-	testCase(ValidationUniqueTests.allTests)
+	testCase(ValidationUniqueTests.allTests),
+    testCase(LocalizationTests.allTests)
 ])
 
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -8,23 +8,23 @@ XCTMain([
     testCase(ConfigTests.allTests),
     testCase(ControllerTests.allTests),
     testCase(EnvironmentTests.allTests),
-	testCase(EventTests.allTests),
+    testCase(EventTests.allTests),
     testCase(HashTests.allTests),
-	testCase(HTTPStreamTests.allTests),
+    testCase(HTTPStreamTests.allTests),
+    testCase(LocalizationTests.allTests)
     testCase(LogTests.allTests),
     testCase(MemorySessionDriverTests.allTests),
-	testCase(PerformanceTests.allTests),
+    testCase(PerformanceTests.allTests),
     testCase(ProcessTests.allTests),
     testCase(ResponseTests.allTests),
     testCase(RouterTests.allTests),
     testCase(RouteTests.allTests),
     testCase(SessionTests.allTests),
-	testCase(TypedRouteTests.allTests),
-	testCase(ValidationConvenienceTests.allTests),
-	testCase(ValidationCountTests.allTests),
-	testCase(ValidationTests.allTests),
-	testCase(ValidationUniqueTests.allTests),
-    testCase(LocalizationTests.allTests)
+    testCase(TypedRouteTests.allTests),
+    testCase(ValidationConvenienceTests.allTests),
+    testCase(ValidationCountTests.allTests),
+    testCase(ValidationTests.allTests),
+    testCase(ValidationUniqueTests.allTests),
 ])
 
 #endif

--- a/Tests/Vapor/LocalizationTests.swift
+++ b/Tests/Vapor/LocalizationTests.swift
@@ -32,5 +32,8 @@ class LocalizationTests: XCTestCase {
             .filter { $0 != "Welcome to Defaults" }
 
         XCTAssert(transformations.count == 0, "localization defaults not working properly")
+
+        let notExist = localization["en", "unknown key"]
+        XCTAssert(notExist == "unknown key")
 	}
 }

--- a/Tests/Vapor/LocalizationTests.swift
+++ b/Tests/Vapor/LocalizationTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Vapor
+
+class LocalizationTests: XCTestCase {
+    static var allTests: [(String, (LocalizationTests) -> () throws -> Void)] {
+        return [
+           ("testSimple", testSimple)
+        ]
+    }
+
+    var workDir: String {
+        let parent = #file.characters.split(separator: "/").map(String.init).dropLast().joined(separator: "/")
+        let path = "/\(parent)/../../Sources/Development/"
+        return path
+    }
+
+    lazy var localization: Localization = Localization(workingDirectory: self.workDir)
+
+    func testSimple() {
+        let english = localization["en", "welcome-text"]
+        XCTAssert(english == "Welcome to Vapor")
+
+        let spanish = localization["es", "welcome-text"]
+        XCTAssert(spanish == "Bienvenidos a Vapor")
+
+        let languagesThatDontExist = ["da", "de", "fr", "th"]
+
+        let transformations = languagesThatDontExist
+            .map { languageCode in
+                return localization[languageCode, "welcome-text"]
+            }
+            .filter { $0 != "Welcome to Defaults" }
+
+        XCTAssert(transformations.count == 0, "localization defaults not working properly")
+	}
+}


### PR DESCRIPTION
Pretty basic localization proposal:

Create Localization Files in `/Localization`

```
- /Localization
    - default.json
    - en.json
    - es.json
```

Doesn't currently support nested folders w/in localization which we'll need if there's demand for localized assets in addition to strings, I don't think that complexity is necessary for our initial implementation, but open to discuss if it's a more common requirement than I think. For now, workaround would be to localize image name when requested.

Syntax:

```Swift
let text = localization["en", "welcome-text"]
```

I'm hesitant about adding this to `App` since that will encourage capturing `self` w/in the closures. We should see if we can come up with another way to provide access. We could also just leave it global for users to implement manually however they prefer.

#251 