### PR TITLE
Make Hash initializer public

### DIFF
--- a/Sources/Vapor/Hash/Hash.swift
+++ b/Sources/Vapor/Hash/Hash.swift
@@ -24,6 +24,13 @@ public class Hash {
     public var driver: HashDriver = SHA2Hasher(variant: .sha256)
 
     /**
+        Initialize the Hash.
+    */
+    public init() {
+
+    }
+
+    /**
         Hashes a string using the `Hash` class's
         current `HashDriver` and `applicationString` salt.
 

--- a/Sources/Vapor/Hash/Hash.swift
+++ b/Sources/Vapor/Hash/Hash.swift
@@ -13,7 +13,7 @@ public class Hash {
         the same during the lifetime of your application, since
         changing it will result in mismatching hashes.
     */
-    public var key: String = ""
+    private let key: String
 
     /**
         Any class that conforms to the `HashDriver`
@@ -21,13 +21,20 @@ public class Hash {
         It will be used to create the hashes
         request by functions like `make()`
     */
-    public var driver: HashDriver = SHA2Hasher(variant: .sha256)
+    private let driver: HashDriver
 
     /**
         Initialize the Hash.
-    */
-    public init() {
 
+        - parameter key: seed the hash with a secret key to add an additional layer of security to all hashes
+
+        - parameter driver: an instance of any class that conforms to the `HashDriver` protocol, defaults to SHA2Hasher
+
+        - warning: Ensure the `key` stays the same during the lifecycle of your application.
+    */
+    public init(key: String, driver: HashDriver = nil) {
+        self.key = key
+        self.driver = driver ?? SHA2Hasher(variant: .sha256)
     }
 
     /**


### PR DESCRIPTION
I believe that the Hash class's initialiser is not made public because configuration of the Hash is expected to be performed by:

    app.hash.key = "secretkey"

However, in the initialiser of Application it is possible to set your own Hash instance, so it would appear to make sense to allow to be inited outside of the scope of the init of an Application.

There are also use cases for being able to have more than one Hash instance (with different keys) available at one time, or having an instance available without needing to create an Application along with it. I also can't think of any particularly good reasons for disallowing it, hence this pull request.