### PR TITLE
Make Hash initializer public

### DIFF
--- a/Sources/Vapor/Hash/Hash.swift
+++ b/Sources/Vapor/Hash/Hash.swift
@@ -24,6 +24,13 @@ public class Hash {
     public var driver: HashDriver = SHA2Hasher(variant: .sha256)
 
     /**
+        Initialize the Hash.
+    */
+    public init() {
+
+    }
+
+    /**
         Hashes a string using the `Hash` class's
         current `HashDriver` and `applicationString` salt.
 


### PR DESCRIPTION
[Repeat of #336, addresses #195]

I believe that the Hash class's initialiser is not made public because configuration of the Hash is expected to be performed by:

    app.hash.key = "secretkey"

However, in the initialiser of Application it is possible to set your own Hash instance, so it would appear to make sense to allow to be inited outside of the scope of the init of an Application.

There are also use cases for being able to have more than one Hash instance (with different keys) available at one time, or having an instance available without needing to create an Application along with it. I also can't think of any particularly good reasons for disallowing it, hence this pull request.