### PR TITLE
Make Hash's key and driver private and immutable

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -12,9 +12,9 @@ var workDir: String {
     return path
 }
 
-let app = Application(config: config, workDir: workDir)
+let hashKey = config["app", "hash", "key"].string ?? "default-key"
 
-app.hash.key = app.config["app", "hash", "key"].string ?? "default-key"
+let app = Application(config: config, workDir: workDir, hash: Hash(withKey: hashKey))
 
 //MARK: Basic
 

--- a/Sources/Vapor/Hash/Hash.swift
+++ b/Sources/Vapor/Hash/Hash.swift
@@ -24,6 +24,13 @@ public class Hash {
     public var driver: HashDriver = SHA2Hasher(variant: .sha256)
 
     /**
+        Initialize the Hash.
+    */
+    public init() {
+
+    }
+
+    /**
         Hashes a string using the `Hash` class's
         current `HashDriver` and `applicationString` salt.
 

--- a/Sources/Vapor/Hash/Hash.swift
+++ b/Sources/Vapor/Hash/Hash.swift
@@ -5,29 +5,23 @@ import libc
 */
 public class Hash {
 
-    /**
-        The `key` adds an additional layer
-        of security to all hashes.
+    private let key: String
 
-        Ensure this key stays
-        the same during the lifetime of your application, since
-        changing it will result in mismatching hashes.
-    */
-    public var key: String = ""
-
-    /**
-        Any class that conforms to the `HashDriver`
-        protocol may be set as the `Hash`'s driver.
-        It will be used to create the hashes
-        request by functions like `make()`
-    */
-    public var driver: HashDriver = SHA2Hasher(variant: .sha256)
+    private let driver: HashDriver
 
     /**
         Initialize the Hash.
-    */
-    public init() {
 
+        - parameter key: a string used to add an additional layer of security to all hashes
+        - parameter driver: instance of a class conforming to the HashDriver protocol,
+                            defaulting to SHA2Hasher(.sha256), used to create hashes
+
+        - warning: Ensure the key stays the same during the lifetime of your application,
+                   since changing it will result in mismatching hashes.
+    */
+    public init(withKey key: String = "", driver: HashDriver? = nil) {
+        self.key = key
+        self.driver = driver ?? SHA2Hasher(variant: .sha256)
     }
 
     /**

--- a/Tests/Vapor/HashTests.swift
+++ b/Tests/Vapor/HashTests.swift
@@ -18,23 +18,21 @@ class HashTests: XCTestCase {
     }
 
     func testHash() {
-        let app = Application()
 
         let string = "vapor"
         let defaultExpected = "97ce9a45eaf0b1ceafc3bba00dfec047526386bbd69241e4a4f0c9fde7c638ea"
         let defaultKey = "123"
 
         //test app facade
-        app.hash.key = defaultKey
+        let app = Application(hash: Hash(withKey: defaultKey))
         let result = app.hash.make(string)
         XCTAssert(defaultExpected == result, "Hash did not match")
 
-        //change key
-        app.hash.key = "1234"
-        let badResult = app.hash.make(string)
-        XCTAssert(defaultExpected != badResult, "Hash matched bad result")
+        //test Hash by itself
+        let hash = Hash(withKey: defaultKey, driver: SHA2Hasher(variant: .sha256))
+        XCTAssert(defaultExpected == hash.make(string), "Hash did not match")
 
-        //test all variants manually
+        //test all variants of manually
         var expected: [SHA2Hasher.Variant: String] = [:]
         expected[.sha256] = "97ce9a45eaf0b1ceafc3bba00dfec047526386bbd69241e4a4f0c9fde7c638ea"
         expected[.sha384] = "3977579292ed6c50588c5e2e345e84470a8e7f2635ecd89cacedb9d747d05bddb767c2c6943f7ed8ae3abf8c8000bd89"


### PR DESCRIPTION
Re the discussion on #336:

I have made the `key` and `driver` properties of `Hash` both private and immutable. They are set at `init()` only.

Benefit: once initialised, it's impossible to accidentally change the parameters of an app's hasher which would cause all kinds of problems as alluded to in the documentation previously attributed to `key`.

Drawback: it's no longer possible to configure an app's hasher after `Application.init()`. Therefore, for configuration of an app's hasher, a code change will have to be made:

    // Prior to this PR
    let app = Application()
    app.hash.key = "secretkey"
    // With this PR
    let app = Application(hash: Hash(withKey: "secretkey"))

NB 1. I have left default values for both `driver` and `key`, so that Hash can still be instantiated with no arguments, which means that anybody not using the hash system (or at least not setting a secret key) will have no code changes and can still simply use `let app = Application()`. This does mean that a hasher used with the default key value is unsafe, but at least this doesn't change any behaviour:

NB 2. I removed documentation comments from the private properties and applied them to the init method only, because I noticed this is how other classes with private properties were handled.