### PR TITLE
rename update to replace to be more explicit about expected behavior

### DIFF
--- a/Sources/Development/Controllers/UserController.swift
+++ b/Sources/Development/Controllers/UserController.swift
@@ -37,9 +37,9 @@ class UserController: Controller {
     }
 
     /** 
-        Update an instance.
-     */
-    func update(_ request: Request, item user: User) throws -> ResponseRepresentable {
+        Replace an existing an instance.
+    */
+    func replace(_ request: Request, item user: User) throws -> ResponseRepresentable {
         //Testing JsonRepresentable
         return user.makeJson()
     }

--- a/Sources/Vapor/Routing/Application+Route.swift
+++ b/Sources/Vapor/Routing/Application+Route.swift
@@ -66,7 +66,7 @@ extension Application {
 
         //PUT /entities/:id
         self.put(path, Resource.Item.self) { request, item in
-            return try controllerFactory().update(request, item: item)
+            return try controllerFactory().replace(request, item: item)
         }
 
         //DELETE /entities

--- a/Sources/Vapor/Routing/ResourceController.swift
+++ b/Sources/Vapor/Routing/ResourceController.swift
@@ -25,7 +25,7 @@ public protocol ResourceController {
     /**
         Update an instance.
      */
-    func update(_ request: Request, item: Item) throws -> ResponseRepresentable
+    func replace(_ request: Request, item: Item) throws -> ResponseRepresentable
 
     /**
         Modify an instance (only the fields that are present in the request)
@@ -69,7 +69,7 @@ extension ResourceController {
     /**
         Update an instance.
      */
-    public func update(_ request: Request, item: Item) throws -> ResponseRepresentable {
+    public func replace(_ request: Request, item: Item) throws -> ResponseRepresentable {
         throw Abort.notFound
     }
 

--- a/Tests/Vapor/ControllerTests.swift
+++ b/Tests/Vapor/ControllerTests.swift
@@ -50,7 +50,7 @@ private class TestController: Controller {
     /**
         Update an instance.
      */
-    func update(_ request: Request, item: String) throws -> Vapor.ResponseRepresentable {
+    func replace(_ request: Request, item: String) throws -> Vapor.ResponseRepresentable {
         lock.update += 1
         return "update"
     }


### PR DESCRIPTION
I'd liek to rename `update` to `replace` to be more clear about expected behavior