### PR TITLE
Fixed overflow error for certain linux builds when casting UInt32.max to Int

### DIFF
--- a/Sources/Vapor/WebSockets/Model/Frame.swift
+++ b/Sources/Vapor/WebSockets/Model/Frame.swift
@@ -354,7 +354,7 @@ extension WebSocket.Frame {
             guard isMasked else { return .none }
 
             #if os(Linux)
-                let key = UInt32(libc.random() % Int(UInt32.max))
+                let key = UInt32(libc.random()) % UInt32.max
             #else
                 let key = UInt32(arc4random_uniform(UInt32.max))
             #endif


### PR DESCRIPTION
issue described in #409 