### PR TITLE
Fix for changes implemented in upcoming swift snapshot

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,6 +2,26 @@ import PackageDescription
 
 let package = Package(
     name: "Vapor",
+        targets: [
+        Target(
+            name: "Vapor"
+        ),
+        Target(
+            name: "Development",
+            dependencies: [
+                .Target(name: "Vapor")
+            ]
+        ),
+        Target(
+            name: "Performance",
+            dependencies: [
+                .Target(name: "Vapor")
+            ]
+        ),
+        Target(
+            name: "Generator"
+        )
+    ],
     dependencies: [
         //Standards package. Contains protocols for cross-project compatability.
         .Package(url: "https://github.com/open-swift/S4.git", majorVersion: 0, minor: 10),
@@ -38,25 +58,5 @@ let package = Package(
         "XcodeProject",
         "Generator",
         "Development"
-    ],
-    targets: [
-        Target(
-            name: "Vapor"
-        ),
-        Target(
-            name: "Development",
-            dependencies: [
-                .Target(name: "Vapor")
-            ]
-        ),
-        Target(
-            name: "Performance",
-            dependencies: [
-                .Target(name: "Vapor")
-            ]
-        ),
-        Target(
-            name: "Generator"
-        )
     ]
 )

--- a/Sources/Vapor/Application/Application.swift
+++ b/Sources/Vapor/Application/Application.swift
@@ -138,7 +138,7 @@ public class Application {
             databaseProvided = provider.database ?? databaseProvided
         }
 
-        let arguments = arguments ?? NSProcessInfo.processInfo().arguments
+        let arguments = arguments ?? ProcessInfo.processInfo().arguments
         self.arguments = arguments
 
         let console = consoleProvided ?? Terminal()

--- a/Sources/Vapor/Config/Config.swift
+++ b/Sources/Vapor/Config/Config.swift
@@ -48,7 +48,7 @@ public class Config {
         seed: JSON = [:],
         workingDirectory: String = "./",
         environment: Environment? = nil,
-        arguments: [String] = NSProcessInfo.processInfo().arguments
+        arguments: [String] = ProcessInfo.processInfo().arguments
     ) throws {
         let configDirectory = workingDirectory.finish("/") + "Config/"
         self.environment = environment ?? Environment.loader(arguments: arguments)
@@ -82,7 +82,7 @@ public class Config {
     }
 
     public init() {
-        self.environment = Environment.loader(arguments: NSProcessInfo.processInfo().arguments)
+        self.environment = Environment.loader(arguments: ProcessInfo.processInfo().arguments)
         self.directoryQueue = PrioritizedDirectoryQueue(directories: [])
     }
 

--- a/Sources/Vapor/Date/Date+RFC1123.swift
+++ b/Sources/Vapor/Date/Date+RFC1123.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension NSDate {
+extension Date {
     public var rfc1123: String {
         return RFC1123.shared.formatter.string(from: self)
     }

--- a/Sources/Vapor/Date/RFC1123.swift
+++ b/Sources/Vapor/Date/RFC1123.swift
@@ -3,15 +3,15 @@ import libc
 
 
 struct RFC1123 {
-    static func now() -> String { return NSDate().rfc1123 }
+    static func now() -> String { return Date().rfc1123 }
 
     static let shared = RFC1123()
-    var formatter: NSDateFormatter
+    var formatter: DateFormatter
 
     init() {
-        formatter = NSDateFormatter()
-        formatter.locale = NSLocale(localeIdentifier: "en_US")
-        formatter.timeZone = NSTimeZone(abbreviation: "GMT")
+        formatter = DateFormatter()
+        formatter.locale = Locale(localeIdentifier: "en_US")
+        formatter.timeZone = TimeZone(abbreviation: "GMT")
         formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss 'GMT'"
     }
 }

--- a/Sources/Vapor/Validation/Convenience/Email.swift
+++ b/Sources/Vapor/Validation/Convenience/Email.swift
@@ -9,14 +9,8 @@ public class Email: ValidationSuite {
                 throw error(with: value)
             }
 
-        // Thanks Ben Wu :)
-        #if os(Linux)
-        let range = value.range(of: ".@.+\\..",
-                                options: .regularExpressionSearch)
-        #else
         let range = value.range(of: ".@.+\\..",
                                 options: .regularExpression)
-        #endif
         guard let _ = range else {
             throw error(with: value)
         }


### PR DESCRIPTION
This pull request takes care of the latest changes in the compiler (SE0060),
order of the arguments in Package.swift
And dropping the `NS` prefix in some Foundation types. (SE0086)
Merge when moving to a new swift snapshot.