### PR TITLE
Async support

### DIFF
--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -481,7 +481,7 @@ app.get("chunked") { request in
                     let response = try HTTPClient<FoundationStream>.get(beyonceQuery)
                     let artists = response.data["artists", "items", "name"].array ?? []
                     let artistsJSON = artists.flatMap { $0.string } .map { JSON.string($0) }
-                    let js = JSON.array(artists.flatMap { $0.string } .map { JSON.string($0) })
+                    let js = JSON.array(artistsJSON)
                     promise.send(js)
                 } catch {
                     promise.send(error)

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -16,33 +16,6 @@ public final class S {
 
 import Foundation
 
-public func orig_asyncPromise<T>(returning: T.Type = T.self, _ handler: (S) throws -> Void) throws -> T {
-    let semaphore = DispatchSemaphore(value: 0)
-
-    print("Before")
-    let url = URL(string: "https://api.spotify.com/v1/search/?q=beyonce&type=artist")
-    URLSession.shared().dataTask(with: url!) { data, response, error in
-        print("Completed Task")
-//        print("Got data: \(data) response: \(response) error: \(error)")
-//        let str = String(data: data!, encoding: .utf8)
-//        print(str)
-//        print("")
-        semaphore.signal()
-    } .resume()
-
-    print("Past")
-
-    let result = semaphore.wait(timeout: .distantFuture)
-    switch result {
-    case .Success:
-        print("Great Success")
-    case .TimedOut:
-        print("Uh Oh!")
-    }
-
-    fatalError()
-}
-
 public enum Result<T> {
     case success(T)
     case failure(ErrorProtocol)
@@ -72,32 +45,30 @@ public final class Sender<T> {
     }
 
     public func send(_ value: T) {
+        // TODO: Fatal error or throw? It's REALLY convenient NOT to throw here. Should at least log warning
+        guard result == nil else { return }
         result = .success(value)
         semaphore.signal()
     }
 
     public func send(_ error: ErrorProtocol) {
+        guard result == nil else { return }
         result = .failure(error)
         semaphore.signal()
     }
 }
 
-public func asyncPromise<T>(returning: T.Type = T.self, _ handler: (Sender<T>) throws -> Void) throws -> T {
-    print("0")
+public func asyncPromise<T>(returning: T.Type = T.self, timeout: DispatchTime = .distantFuture, _ handler: (Sender<T>) throws -> Void) throws -> T {
     let semaphore = DispatchSemaphore(value: 0)
-    print("1")
     let sender = Sender<T>(semaphore)
     // Ok to call synchronously, since will still unblock semaphore
-    print("2")
     // TODO: Find a way to enforce sender is called, not calling will perpetually block w/ long timeout
     try handler(sender)
-    print("3")
     // TODO: Expose timeout customization -- I think Foundation is missing initializer
-    let semaphoreResult = semaphore.wait(timeout: .distantFuture)
-    print("4")
+    let semaphoreResult = semaphore.wait(timeout: timeout)
     switch semaphoreResult {
     case .Success:
-        guard let result = sender.result else { throw AsyncPromiseError.unexpectedEmptyResult }
+        guard let result = sender.result else { throw AsyncPromiseError.senderNotCalled }
         return try result.extract()
     case .TimedOut:
         throw AsyncPromiseError.timedOut

--- a/Sources/Development/main.swift
+++ b/Sources/Development/main.swift
@@ -482,9 +482,9 @@ app.get("chunked") { request in
                     let artists = response.data["artists", "items", "name"].array ?? []
                     let artistsJSON = artists.flatMap { $0.string } .map { JSON.string($0) }
                     let js = JSON.array(artistsJSON)
-                    promise.send(js)
+                    promise.resolve(with: js)
                 } catch {
-                    promise.send(error)
+                    promise.reject(with: error)
                 }
             }
         }

--- a/Sources/Vapor/Async/Promise.swift
+++ b/Sources/Vapor/Async/Promise.swift
@@ -43,7 +43,6 @@
             // Ok to call synchronously, since will still unblock semaphore
             // TODO: Find a way to enforce sender is called, not calling will perpetually block w/ long timeout
             try handler(sender)
-            // TODO: Expose timeout customization -- I think Foundation is missing initializer
             let semaphoreResult = semaphore.wait(timeout: timeout)
             switch semaphoreResult {
             case .Success:

--- a/Sources/Vapor/Async/Promise.swift
+++ b/Sources/Vapor/Async/Promise.swift
@@ -11,8 +11,9 @@
         case timedOut
     }
 
-    // TODO: Is Promise the right word here?
-
+    /*:
+        This class is designed to make it possible to use asynchronous contexts in a synchronous environment.
+    */
     public final class Promise<T> {
         private var result: Result<T>? = .none
         private let semaphore: DispatchSemaphore
@@ -22,6 +23,9 @@
             self.semaphore = semaphore
         }
 
+        /*:
+            Resolve the promise with a successful result
+        */
         public func resolve(with value: T) {
             lock.locked {
                 // TODO: Fatal error or throw? It's REALLY convenient NOT to throw here. Should at least log warning
@@ -31,6 +35,9 @@
             }
         }
 
+        /*:
+            Reject the promise with an appropriate error
+        */
         public func reject(with error: ErrorProtocol) {
             lock.locked {
                 guard result == nil else { return }
@@ -41,6 +48,23 @@
     }
 
     extension Promise {
+        /*:
+            This function is used to enter an asynchronous supported context with a promise
+            object that can be used to complete a given operation.
+         
+                let value = try Promise<Int>.async { promise in 
+                    // .. do whatever necessary passing around `promise` object
+                    // eventually call
+                    
+                    promise.resolve(with: 42)
+                    
+                    // or
+         
+                    promise.resolve(with: errorSignifyingFailure)
+                }
+         
+            - warning: Calling a `promise` multiple times will have no effect.
+        */
         public static func async(timingOut timeout: DispatchTime = .distantFuture,
                                  _ handler: (Promise) throws -> Void) throws -> T {
             let semaphore = DispatchSemaphore(value: 0)

--- a/Sources/Vapor/Async/Response+Async.swift
+++ b/Sources/Vapor/Async/Response+Async.swift
@@ -5,7 +5,13 @@
     /*
      Temporarily not available on Linux until Foundation's 'Dispatch apis are available
      */
+
     extension Response {
+        /*:
+            Sometimes, asynchronicity is required within Vapor's synchronous environment. 
+            Use this function to enter an async context in which the 'promixe' object can
+            be passed to multiple threads and called when appropriate
+        */
         public static func async(timingOut timeout: DispatchTime = .distantFuture, _ handler: (Promise<ResponseRepresentable>) throws -> Void) throws -> ResponseRepresentable {
             return try Promise.async(timingOut: timeout, handler)
         }

--- a/Sources/Vapor/Async/Response+Async.swift
+++ b/Sources/Vapor/Async/Response+Async.swift
@@ -1,0 +1,13 @@
+#if !os(Linux)
+
+    import Foundation
+
+    /*
+     Temporarily not available on Linux until Foundation's 'Dispatch apis are available
+     */
+    extension Response {
+        public static func async(timingOut timeout: DispatchTime = .distantFuture, _ handler: (Promise<ResponseRepresentable>) throws -> Void) throws -> ResponseRepresentable {
+            return try Promise.async(timingOut: timeout, handler)
+        }
+    }
+#endif

--- a/Sources/Vapor/AsyncPromise/AsyncPromise.swift
+++ b/Sources/Vapor/AsyncPromise/AsyncPromise.swift
@@ -1,0 +1,74 @@
+
+import Foundation
+
+public enum Result<T> {
+    case success(T)
+    case failure(ErrorProtocol)
+
+    public func extract() throws -> T {
+        switch self {
+        case .success(let val):
+            return val
+        case .failure(let e):
+            throw e
+        }
+    }
+}
+
+public enum PromiseError: ErrorProtocol {
+    case promiseNotCalled
+    case timedOut
+}
+
+// TODO: Is Promise the right word here?
+
+public final class Promise<T> {
+    private var result: Result<T>? = .none
+    private let semaphore: DispatchSemaphore
+
+    private init(_ semaphore: DispatchSemaphore) {
+        self.semaphore = semaphore
+    }
+
+    public func send(_ value: T) {
+        // TODO: Fatal error or throw? It's REALLY convenient NOT to throw here. Should at least log warning
+        guard result == nil else { return }
+        result = .success(value)
+        semaphore.signal()
+    }
+
+    public func send(_ error: ErrorProtocol) {
+        guard result == nil else { return }
+        result = .failure(error)
+        semaphore.signal()
+    }
+}
+
+extension Promise {
+    public static func async(timingOut timeout: DispatchTime = .distantFuture,
+                             with handler: (Promise) throws -> Void) throws -> T {
+        let semaphore = DispatchSemaphore(value: 0)
+        let sender = Promise<T>(semaphore)
+        // Ok to call synchronously, since will still unblock semaphore
+        // TODO: Find a way to enforce sender is called, not calling will perpetually block w/ long timeout
+        try handler(sender)
+        // TODO: Expose timeout customization -- I think Foundation is missing initializer
+        let semaphoreResult = semaphore.wait(timeout: timeout)
+        switch semaphoreResult {
+        case .Success:
+            guard let result = sender.result else { throw PromiseError.promiseNotCalled }
+            return try result.extract()
+        case .TimedOut:
+            throw PromiseError.timedOut
+        }
+    }
+}
+
+public protocol Empty {}
+extension HTTPResponse: Empty {}
+
+extension Empty where Self: HTTPResponse {
+    public init(async: (Promise<Self>) throws -> Void) throws {
+        self = try Promise.async(with: async)
+    }
+}

--- a/Sources/Vapor/AsyncPromise/AsyncPromise.swift
+++ b/Sources/Vapor/AsyncPromise/AsyncPromise.swift
@@ -46,7 +46,7 @@ public final class Promise<T> {
 
 extension Promise {
     public static func async(timingOut timeout: DispatchTime = .distantFuture,
-                             with handler: (Promise) throws -> Void) throws -> T {
+                             _ handler: (Promise) throws -> Void) throws -> T {
         let semaphore = DispatchSemaphore(value: 0)
         let sender = Promise<T>(semaphore)
         // Ok to call synchronously, since will still unblock semaphore
@@ -64,11 +64,8 @@ extension Promise {
     }
 }
 
-public protocol Empty {}
-extension HTTPResponse: Empty {}
-
-extension Empty where Self: HTTPResponse {
-    public init(async: (Promise<Self>) throws -> Void) throws {
-        self = try Promise.async(with: async)
+extension Response {
+    public static func async(timingOut timeout: DispatchTime = .distantFuture, _ handler: (Promise<ResponseRepresentable>) throws -> Void) throws -> ResponseRepresentable {
+        return try Promise.async(timingOut: timeout, handler)
     }
 }

--- a/Sources/Vapor/AsyncPromise/AsyncPromise.swift
+++ b/Sources/Vapor/AsyncPromise/AsyncPromise.swift
@@ -1,71 +1,64 @@
+#if !os(Linux)
 
-import Foundation
+    import Foundation
 
-public enum Result<T> {
-    case success(T)
-    case failure(ErrorProtocol)
+    /*
+     Temporarily not available on Linux until Foundation's 'Dispatch apis are available
+     */
 
-    public func extract() throws -> T {
-        switch self {
-        case .success(let val):
-            return val
-        case .failure(let e):
-            throw e
+    public enum PromiseError: ErrorProtocol {
+        case promiseNotCalled
+        case timedOut
+    }
+
+    // TODO: Is Promise the right word here?
+
+    public final class Promise<T> {
+        private var result: Result<T>? = .none
+        private let semaphore: DispatchSemaphore
+
+        private init(_ semaphore: DispatchSemaphore) {
+            self.semaphore = semaphore
+        }
+
+        public func send(_ value: T) {
+            // TODO: Fatal error or throw? It's REALLY convenient NOT to throw here. Should at least log warning
+            guard result == nil else { return }
+            result = .success(value)
+            semaphore.signal()
+        }
+
+        public func send(_ error: ErrorProtocol) {
+            guard result == nil else { return }
+            result = .failure(error)
+            semaphore.signal()
         }
     }
-}
 
-public enum PromiseError: ErrorProtocol {
-    case promiseNotCalled
-    case timedOut
-}
-
-// TODO: Is Promise the right word here?
-
-public final class Promise<T> {
-    private var result: Result<T>? = .none
-    private let semaphore: DispatchSemaphore
-
-    private init(_ semaphore: DispatchSemaphore) {
-        self.semaphore = semaphore
-    }
-
-    public func send(_ value: T) {
-        // TODO: Fatal error or throw? It's REALLY convenient NOT to throw here. Should at least log warning
-        guard result == nil else { return }
-        result = .success(value)
-        semaphore.signal()
-    }
-
-    public func send(_ error: ErrorProtocol) {
-        guard result == nil else { return }
-        result = .failure(error)
-        semaphore.signal()
-    }
-}
-
-extension Promise {
-    public static func async(timingOut timeout: DispatchTime = .distantFuture,
-                             _ handler: (Promise) throws -> Void) throws -> T {
-        let semaphore = DispatchSemaphore(value: 0)
-        let sender = Promise<T>(semaphore)
-        // Ok to call synchronously, since will still unblock semaphore
-        // TODO: Find a way to enforce sender is called, not calling will perpetually block w/ long timeout
-        try handler(sender)
-        // TODO: Expose timeout customization -- I think Foundation is missing initializer
-        let semaphoreResult = semaphore.wait(timeout: timeout)
-        switch semaphoreResult {
-        case .Success:
-            guard let result = sender.result else { throw PromiseError.promiseNotCalled }
-            return try result.extract()
-        case .TimedOut:
-            throw PromiseError.timedOut
+    extension Promise {
+        public static func async(timingOut timeout: DispatchTime = .distantFuture,
+                                 _ handler: (Promise) throws -> Void) throws -> T {
+            let semaphore = DispatchSemaphore(value: 0)
+            let sender = Promise<T>(semaphore)
+            // Ok to call synchronously, since will still unblock semaphore
+            // TODO: Find a way to enforce sender is called, not calling will perpetually block w/ long timeout
+            try handler(sender)
+            // TODO: Expose timeout customization -- I think Foundation is missing initializer
+            let semaphoreResult = semaphore.wait(timeout: timeout)
+            switch semaphoreResult {
+            case .Success:
+                guard let result = sender.result else { throw PromiseError.promiseNotCalled }
+                return try result.extract()
+            case .TimedOut:
+                throw PromiseError.timedOut
+            }
         }
     }
-}
 
-extension Response {
-    public static func async(timingOut timeout: DispatchTime = .distantFuture, _ handler: (Promise<ResponseRepresentable>) throws -> Void) throws -> ResponseRepresentable {
-        return try Promise.async(timingOut: timeout, handler)
+    extension Response {
+        public static func async(timingOut timeout: DispatchTime = .distantFuture, _ handler: (Promise<ResponseRepresentable>) throws -> Void) throws -> ResponseRepresentable {
+            return try Promise.async(timingOut: timeout, handler)
+        }
     }
-}
+
+#endif

--- a/Sources/Vapor/Utilities/Result.swift
+++ b/Sources/Vapor/Utilities/Result.swift
@@ -1,0 +1,33 @@
+public enum Result<T> {
+    case success(T)
+    case failure(ErrorProtocol)
+}
+
+extension Result {
+    public func extract() throws -> T {
+        switch self {
+        case .success(let val):
+            return val
+        case .failure(let e):
+            throw e
+        }
+    }
+}
+
+extension Result {
+    public var value: T? {
+        guard case let .success(val) = self else { return nil }
+        return val
+    }
+
+    public var error: ErrorProtocol? {
+        guard case let .failure(err) = self else { return nil }
+        return err
+    }
+}
+
+extension Result {
+    public var succeeded: Bool {
+        return value != nil
+    }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -22,6 +22,7 @@ XCTMain([
     testCase(MemorySessionDriverTests.allTests),
     testCase(PercentEncodingTests.allTests),
     testCase(ProcessTests.allTests),
+    testCase(PromiseTests.allTests),
     testCase(ResponseTests.allTests),
     testCase(RouterTests.allTests),
     testCase(RouteTests.allTests),

--- a/Tests/Vapor/PromiseTests.swift
+++ b/Tests/Vapor/PromiseTests.swift
@@ -1,0 +1,112 @@
+//
+//  PromiseTests.swift
+//  Vapor
+//
+//  Created by Logan Wright on 7/4/16.
+//
+//
+
+import XCTest
+@testable import Vapor
+
+private enum PromiseTestError: ErrorProtocol {
+    case someError
+    case anotherError
+}
+
+class PromiseTests: XCTestCase {
+
+    #if os(Linux)
+    /*
+    Temporary until we get libdispatch support on Linux, then remove this section.
+    */
+    static let allTests = [
+        ("testPromiseResult", testPromiseResult),
+        ("testPromiseFailure", testPromiseFailure),
+        ("testDuplicateResults", testDuplicateResults),
+        ("testDuplicateErrors", testDuplicateErrors)
+    ]
+
+    func testLinux() {
+        print("Not yet available on linux")
+    }
+
+    #else
+    static let allTests = [
+        ("testPromiseResult", testPromiseResult),
+        ("testPromiseFailure", testPromiseFailure),
+        ("testDuplicateResults", testDuplicateResults),
+        ("testDuplicateErrors", testDuplicateErrors)
+    ]
+
+    func testPromiseResult() throws {
+        var array: [Int] = []
+
+        array.append(1)
+        let result: Int = try Promise.async { promise in
+            array.append(2)
+            _ = try background {
+                sleep(1)
+                array.append(4)
+                promise.resolve(with: 42)
+            }
+            array.append(3)
+        }
+        array.append(5)
+
+        XCTAssert(array == [1,2,3,4,5])
+        XCTAssert(result == 42)
+    }
+
+    func testPromiseFailure() {
+        var array: [Int] = []
+
+        do {
+            array.append(1)
+            let _ = try Promise<Int>.async { promise in
+                array.append(2)
+                _ = try background {
+                    sleep(1)
+                    array.append(4)
+                    promise.reject(with: PromiseTestError.someError)
+                }
+                array.append(3)
+            }
+            XCTFail("Promise should throw")
+        } catch PromiseTestError.someError {
+            // success
+        } catch {
+            XCTFail("Unexpected error thrown: \(error)")
+        }
+
+        XCTAssert(array == [1,2,3,4])
+    }
+
+    func testDuplicateResults() throws {
+        let response = try Promise<Int>.async { promise in
+            promise.resolve(with: 10)
+            // subsequent resolutions should be ignored
+            promise.resolve(with: 400)
+        }
+
+        XCTAssert(response == 10)
+    }
+
+
+    func testDuplicateErrors() {
+        do {
+            let _ = try Promise<Int>.async { promise in
+                promise.reject(with: PromiseTestError.someError)
+                // subsequent rejections should be ignored
+                promise.reject(with: PromiseTestError.anotherError)
+            }
+            XCTFail("Test should not pass")
+        } catch PromiseTestError.someError {
+            // success
+        } catch {
+            XCTFail("Unexpected error thrown")
+        }
+    }
+    
+    #endif
+}

--- a/Tests/Vapor/PromiseTests.swift
+++ b/Tests/Vapor/PromiseTests.swift
@@ -21,10 +21,7 @@ class PromiseTests: XCTestCase {
     Temporary until we get libdispatch support on Linux, then remove this section.
     */
     static let allTests = [
-        ("testPromiseResult", testPromiseResult),
-        ("testPromiseFailure", testPromiseFailure),
-        ("testDuplicateResults", testDuplicateResults),
-        ("testDuplicateErrors", testDuplicateErrors)
+        ("testLinux", testLinux)
     ]
 
     func testLinux() {


### PR DESCRIPTION
Temporarily osx only.

- I'm not sure that I'm using the term `Promise` correctly, so open to renaming
- Using static function as opposed to initializer on Response. It is possible to use an initializer, but requires a bit of hackiness to work, that I am not sure adds enough value.

- [x] Tests
- [x] Documentation

This allows asynchronous behavior as an opt-in system w/in a synchronous environment. Available on Linux when Dispatch apis exist.