### PR TITLE
Simplified Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,27 +5,10 @@ var exclude: [String] = []
 exclude.append("Sources/Generator")
 #endif
 
-var targets: [Target] = [
-    Target(
-        name: "Development",
-        dependencies: [
-            .Target(name: "Vapor")
-        ]
-    ),
-    Target(
-        name: "Performance",
-        dependencies: [
-            .Target(name: "Vapor")
-        ]
-    ),
+var targets = [
+    Target(name: "Development", dependencies: ["Vapor"]),
+    Target(name: "Performance", dependencies: ["Vapor"])
 ]
-#if !os(Linux)
-targets += [
-  Target(
-      name: "Generator"
-  )
-]
-#endif
 
 let package = Package(
     name: "Vapor",


### PR DESCRIPTION
This should work exactly the same way, there was no need to explicitly specify the `Generator` target. And dependencies of targets can be just strings, no need to manually create the `.Target` structs.