### PR TITLE
Fixed the model type checking

### DIFF
--- a/Sources/Vapor/Application/Application.swift
+++ b/Sources/Vapor/Application/Application.swift
@@ -229,7 +229,7 @@ public class Droplet {
         if let driver = databaseProvided {
             let database = Database(driver)
             for preparation in preparations {
-                if let model = preparation as? Model.Type {
+                if let model = preparation as? DatabaseModel.Type {
                     model.database = database
                 }
             }


### PR DESCRIPTION
If I:

```Swift
import Fluent

class XYZ: Model {}
```

The model doesn't get initialized since it doesn't fall under the Vapor-defined protocol. Fix is this one liner. 