### PR TITLE
fix slashes in routing

### DIFF
--- a/Sources/HTTPRouting/RouteBuilder+HTTP.swift
+++ b/Sources/HTTPRouting/RouteBuilder+HTTP.swift
@@ -13,7 +13,7 @@ extension Routing.RouteBuilder where Value == HTTP.Responder {
         _ value: (HTTP.Request) throws -> HTTP.ResponseRepresentable
     ) {
         add(
-            path: ["*", method.description] + path,
+            path: ["*", method.description] + path.splitPaths(),
             value: HTTP.Request.Handler({ request in
                 return try value(request).makeResponse()
             })
@@ -28,7 +28,7 @@ extension Routing.RouteBuilder where Value == HTTP.Responder {
     public func group(_ path: String ..., closure: (Routing.RouteGroup<Value, Self>) -> ()) {
         return group(
             prefix: [nil, nil],
-            path: path,
+            path: path.splitPaths(),
             map: nil,
             closure: closure
         )
@@ -56,7 +56,7 @@ extension Routing.RouteBuilder where Value == HTTP.Responder {
     public func grouped(_ path: String ...) -> Routing.RouteGroup<Value, Self> {
         return grouped(
             prefix: [nil, nil],
-            path: path,
+            path: path.splitPaths(),
             map: nil
         )
     }

--- a/Sources/HTTPRouting/Utilities.swift
+++ b/Sources/HTTPRouting/Utilities.swift
@@ -9,3 +9,15 @@ extension String {
             .map { String($0) }
     }
 }
+
+extension Sequence where Iterator.Element == String {
+    func splitPaths() -> [String] {
+        var split: [String] = []
+
+        for path in self {
+            split += path.pathComponents
+        }
+
+        return split
+    }
+}

--- a/Sources/Vapor/Droplet/Droplet+Serve.swift
+++ b/Sources/Vapor/Droplet/Droplet+Serve.swift
@@ -12,6 +12,7 @@ extension Droplet {
     public func serve(_ closure: Serve.ServeFunction? = nil) -> Never  {
         do {
             try runCommands()
+            exit(1)
         } catch CommandError.general(let error) {
             console.output(error, style: .error)
             exit(1)

--- a/Tests/HTTPRouting/AddTests.swift
+++ b/Tests/HTTPRouting/AddTests.swift
@@ -31,4 +31,16 @@ class AddTests: XCTestCase {
         
         XCTAssertEqual(bytes, "1337".bytes)
     }
+
+    func testWithSlash() throws {
+        let router = Router()
+        router.add(.get, "foo/bar") { request in
+            return "foo"
+        }
+
+        let request = Request(method: .get, path: "foo/bar")
+        let bytes = try request.bytes(running: router)
+
+        XCTAssertEqual(bytes, "foo".bytes)
+    }
 }

--- a/Utilities/compatibility.sh
+++ b/Utilities/compatibility.sh
@@ -2,9 +2,8 @@
 
 SWIFTC=`which swift`
 
-VALID_MAC="swiftlang-800.0.33.1"
-VALID_LINUX="swift-3.0-PREVIEW-2"
-VALID_XCB="8S162m"
+VALID="Swift 395e967875"
+VALID_XCB="8S174q"
 
 help() {
 	echo "📖  Visit our docs for step-by-step instructions on installing Swift correctly."
@@ -17,9 +16,11 @@ help() {
 if [[ $SWIFTC == "" ]];
 then
 	echo "❌  Incompatible"
+	echo "Reason: Cannot find Swift."
 	echo ""
-	echo "You don't have Swift installed."
 	echo "'which swift' is empty."
+	echo ""
+	help
 	exit 1;
 fi
 
@@ -27,64 +28,56 @@ SWIFTV=`swift -version`;
 
 OS=`uname`
 
+SWIFTLOC=`which swift`
+SWIFTDESIRED=".swiftenv/shims/swift" 
+if [[ $SWIFTLOC != *$SWIFTDESIRED* ]];
+then
+	echo "⚠️  It looks like you don't have Swiftenv installed."
+	echo ""
+	echo "Current Swift location: $SWIFTLOC"
+	echo "Should contain: $SWIFTDESIRED"
+	echo ""
+	echo "To install: (https://swiftenv.fuller.li/en/latest/)"
+	echo "    git clone https://github.com/kylef/swiftenv.git ~/.swiftenv"
+	echo ""
+	echo "Then add these lines to your Bash Profile:"
+	echo "    export SWIFTENV_ROOT=\"\$HOME/.swiftenv\""
+	echo "    export PATH=\"\$SWIFTENV_ROOT/bin:\$PATH\""
+	echo "    eval \"\$(swiftenv init -)\""
+	echo ""
+fi
+
 if [[ $OS == "Darwin" ]]; # macOS
 then
 	XCBVERSION=`xcodebuild -version`
 	if [[ $XCBVERSION != *$VALID_XCB* ]];
 	then
 		echo "⚠️  It looks like your Command Line Tools version is incorrect."
-		echo "Make sure Xcode > Preferences > Locations > Command Line Tools is set correctly."
+		echo ""
+		echo "Open Xcode and make sure the correct SDK is selected:"
+		echo "👀  Xcode > Preferences > Locations > Command Line Tools"
+		echo ""
 		echo "Correct: Xcode 8.0 ($VALID_XCB)"
 		echo "Current: $XCBVERSION"
 		echo ""
 	fi
-
-	SWIFTLOC=`which swift`
-	SWIFTDESIRED="/usr/bin/swift" 
-	if [[ $SWIFTLOC != $SWIFTDESIRED ]];
-	then
-		echo "⚠️  It looks like your Swift install location has been modified."
-		echo "Correct: $SWIFTDESIRED"
-		echo "Current: $SWIFTLOC"
-		echo ""
-	fi
-
-	if [[ $SWIFTV == *$VALID_MAC* ]];
-	then
-		echo "✅  Compatible"
-		exit 0;
-	else
-		echo "❌  Incompatible"
-		echo ""
-		echo "Reason: Invalid Swift version" 
-		echo "Output must contain '$VALID_MAC'"
-		echo ""
-		echo "Current 'swift -version' output:"
-		echo $SWIFTV
-		echo ""
-		help
-		exit 1;
-	fi
-else # Linux
-	if [[ $SWIFTV == *$VALID_LINUX* ]];
-	then
-		echo "✅  Compatible"
-		exit 0;
-	else
-		echo "❌  Incompatible"
-		echo ""
-		echo "Reason: Invalid Swift version" 
-		echo "Output must contain '$VALID_LINUX'"
-		echo ""
-		echo "Make sure you have Swift 3.0 Preview 2 installed from Swift.org."
-		echo "If you have already installed, then make sure your PATH is pointing to the correct version."
-		echo ""
-		echo "Current 'swift -version' output:"
-		echo $SWIFTV
-		echo ""
-		help
-		exit 1;
-	fi
 fi
 
-
+if [[ $SWIFTV == *$VALID* ]];
+then
+	echo "✅  Compatible"
+	exit 0;
+else
+	echo "❌  Incompatible"
+	echo "Reason: Invalid Swift version" 
+	echo ""
+	echo "Output must contain '$VALID'"
+	echo "Current 'swift -version' output:"
+	echo $SWIFTV
+	echo ""
+	echo "You must have Swiftenv installed with"
+	echo "swift-DEVELOPMENT-SNAPSHOT-2016-07-25-a"
+	echo ""
+	help
+	exit 1;
+fi


### PR DESCRIPTION
Allows syntax like:

```swift
drop.get("foo/bar") { req in ... }
```