### PR TITLE
Fix crash when collecting the body

### DIFF
--- a/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
+++ b/Sources/Vapor/Concurrency/RoutesBuilder+Concurrency.swift
@@ -128,7 +128,9 @@ extension RoutesBuilder {
     {
         let responder = AsyncBasicResponder { request in
             if case .collect(let max) = body, request.body.data == nil {
-                _ = try await request.body.collect(max: max?.value ?? request.application.routes.defaultMaxBodySize.value).get()
+                _ = try await request.eventLoop.flatSubmit {
+                    request.body.collect(max: max?.value ?? request.application.routes.defaultMaxBodySize.value)
+                }.get()
                 
             }
             return try await closure(request).encodeResponse(for: request)


### PR DESCRIPTION
Fixes an issue where users may experience a crash when collecting the body in async routes due to pre-concurrency assumptions made by Vapor.

Resolves #2990 