### PR TITLE
Consistently use the value from `X-Request-Id` as the request's ID when present

### DIFF
--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -312,7 +312,7 @@ public final class Request: CustomStringConvertible, Sendable {
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         on eventLoop: EventLoop
     ) {
-        let requestId = headers[.xRequestId].first ?? UUID().uuidString
+        let requestId = headers.first(name: .xRequestId) ?? UUID().uuidString
         let bodyStorage: BodyStorage
         if let body = collectedBody {
             bodyStorage = .collected(body)

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -54,7 +54,10 @@ public final class Request: CustomStringConvertible, Sendable {
         }
     }
     
-    /// A uniquely generated ID for each request
+    /// A unique ID for the request.
+    ///
+    /// The request identifier is set to value of the `X-Request-Id` header when present, or to a
+    /// uniquelly generated value otherwise.
     public let id: String
     
     // MARK: Metadata
@@ -309,6 +312,7 @@ public final class Request: CustomStringConvertible, Sendable {
         byteBufferAllocator: ByteBufferAllocator = ByteBufferAllocator(),
         on eventLoop: EventLoop
     ) {
+        let requestId = headers[.xRequestId].first ?? UUID().uuidString
         let bodyStorage: BodyStorage
         if let body = collectedBody {
             bodyStorage = .collected(body)
@@ -317,11 +321,7 @@ public final class Request: CustomStringConvertible, Sendable {
         }
         
         var logger = logger
-        if let requestId = headers[.xRequestId].first {
-            logger[metadataKey: "request-id"] = .string(requestId)
-        } else {
-            logger[metadataKey: "request-id"] = .string(UUID().uuidString)
-        }
+        logger[metadataKey: "request-id"] = .string(requestId)
         self._logger = .init(logger)
         
         let storageBox = RequestBox(
@@ -335,7 +335,7 @@ public final class Request: CustomStringConvertible, Sendable {
             byteBufferAllocator: byteBufferAllocator
         )
         self.requestBox = .init(storageBox)
-        self.id = UUID().uuidString
+        self.id = requestId
         self.application = application
         
         self.remoteAddress = remoteAddress

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -29,6 +29,18 @@ final class RequestTests: XCTestCase {
         XCTAssertNotEqual(request1.id, request2.id)
     }
 
+    func testRequestIdInLoggerMetadata() throws {
+        let app = Application(.testing)
+        defer { app.shutdown() }
+        
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        guard case .string(let string) = request.logger[metadataKey: "request-id"] else {
+            XCTFail("Did not find request-id key in logger metadata.")
+            return
+        }
+        XCTAssertEqual(string, request.id)
+    }
+
     func testRequestPeerAddressForwarded() throws {
         let app = Application(.testing)
         defer { app.shutdown() }
@@ -104,7 +116,7 @@ final class RequestTests: XCTestCase {
         defer { app.shutdown() }
 
         app.get("remote") {
-            if case .string(let string) = $0.logger[metadataKey: "request-id"] {
+            if case .string(let string) = $0.logger[metadataKey: "request-id"], string == $0.id {
                 return string
             } else {
                 throw Abort(.notFound)


### PR DESCRIPTION
**These changes are now available in [4.89.2](https://github.com/vapor/vapor/releases/tag/4.89.2)**


### Changes

This PR ensures that the Request's `id` and  the value of the logger's `request-id` value are the same.

### Motivation

The Request's `id` property was added in #2964 to expose the `request-id` identifier used for logging.

#3072 changed this behavior. The `request-id` identifier is now set:
* to the value from the `X-Request-Id` header, when the header is present,
* to a random identifier, when the header is absent.

Having two different identifiers is confusing. So, this PR reconciles the two values.

### History

The first version of this PR allowed the two identifiers to differ when the `X-Request-Id` header is present, in order to maintain the original semantics of the `id` property.