### PR TITLE
Allow parsing of non-ASCII URIs

### DIFF
--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -200,7 +200,8 @@ public struct URI: Sendable, ExpressibleByStringInterpolation, CustomStringConve
 
     private func parse(_ component: Component) -> String? {
         var url = vapor_urlparser_url()
-        vapor_urlparser_parse(self.string, self.string.count, 0, &url)
+        let utf8View = self.string.utf8
+        vapor_urlparser_parse(self.string, utf8View.count, 0, &url)
         let data: vapor_urlparser_field_data
         switch component {
         case .scheme:
@@ -221,8 +222,8 @@ public struct URI: Sendable, ExpressibleByStringInterpolation, CustomStringConve
         if data.len == 0 {
             return nil
         }
-        let start = self.string.index(self.string.startIndex, offsetBy: numericCast(data.off))
-        let end = self.string.index(start, offsetBy: numericCast(data.len))
-        return String(self.string[start..<end])
+        let start = utf8View.index(utf8View.startIndex, offsetBy: numericCast(data.off))
+        let end = utf8View.index(start, offsetBy: numericCast(data.len))
+        return String(utf8View[start..<end])
     }
 }

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -230,6 +230,11 @@ final class RequestTests: XCTestCase {
             let uri = URI()
             XCTAssertEqual(uri.string, "/")
         }
+        do {
+            let uri = URI(string: "http://test/😀?👍")
+            XCTAssertEqual(uri.path, "/😀")
+            XCTAssertEqual(uri.query, "👍")
+        }
     }
     
     func testRedirect() throws {


### PR DESCRIPTION
While the HTTP parser rejects URLs containing unescaped non-ASCII characters, `URI` values may be constructed from other sources and the current implementation allows any String to be used as an `URI`. We should therefore be ready to safely parse an `URI` containing non-ASCII characters.

`vapor_urlparser_parse` operates on bytes while `URI` treats string as a collection of `Character`. This causes parsed components to be shifted toward the end.

For example, `http://test/😀?👍#12345678` currently parses as:
* scheme: `http`
* host: `test`
* path: `/😀?👍`
* query: `2345`
* fragment: `78`

 This PR computes the buffer length and component ranges using the string's UTF8 view.