### PR TITLE
Preserve empty path when constructing a URI

### DIFF
--- a/Sources/Vapor/Utilities/URI.swift
+++ b/Sources/Vapor/Utilities/URI.swift
@@ -82,7 +82,7 @@ public struct URI: Sendable, ExpressibleByStringInterpolation, CustomStringConve
         }
         if path.hasPrefix("/") {
             string += path
-        } else {
+        } else if !path.isEmpty {
             string += "/" + path
         }
         if let query = query {

--- a/Tests/VaporTests/RequestTests.swift
+++ b/Tests/VaporTests/RequestTests.swift
@@ -155,10 +155,12 @@ final class RequestTests: XCTestCase {
             XCTAssertEqual(uri.path, "/")
         }
         do {
-            let uri = URI(string: "http://foo")
+            var uri = URI(string: "http://foo")
             XCTAssertEqual(uri.scheme, "http")
             XCTAssertEqual(uri.host, "foo")
             XCTAssertEqual(uri.path, "")
+            uri.query = "bar"
+            XCTAssertEqual(uri.string, "http://foo?bar")
         }
         do {
             let uri = URI(string: "foo")


### PR DESCRIPTION
### Motivation

When constructing a URI from its component, an empty path is replaced by `"/"`.

This means that any of `URI`'s setters may update the path:

```swift
var uri = URI(string: "http://foo")
uri.query = "bar"
// uri is now "http://foo/?bar"
```

This also means that while an `URI`'s path may be empty, trying to set a `URI`'s path to the empty string actually sets the path to `"/"`.

```swift
var uri = URI(string: "http://foo")
uri.path = ""
// uri.path is now "/"
```

This PR adds an extra check to preserve the empty path. 
