### PR TITLE
Delete socket file if it exists. Fixes #3085.

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -418,7 +418,7 @@ private final class HTTPServerConnection: Sendable {
         case .hostname:
             channel = bootstrap.bind(host: configuration.hostname, port: configuration.port)
         case .unixDomainSocket(let socketPath):
-            channel = bootstrap.bind(unixDomainSocketPath: socketPath)
+            channel = bootstrap.bind(unixDomainSocketPath: socketPath, cleanupExistingSocketFile: true)
         }
         
         return channel.map { channel in


### PR DESCRIPTION
#3085: If Unix domain socket file exists then Vapor crashes when starting instead of taking over the socket file.

This PR fixes by deleting the socket file if it exists.