### PR TITLE
Fix EndpointCache

### DIFF
--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -37,7 +37,7 @@ public final class EndpointCache<T>: Sendable where T: Decodable & Sendable {
     ///   - request: The `Request` which is initiating the download.
     ///   - logger: An optional logger
     public func get(on request: Request, logger: Logger? = nil) -> EventLoopFuture<T> {
-        return self.download(on: request.eventLoop, using: request.client, logger: logger ?? request.logger)
+        return self.get(using: request.client, logger: logger ?? request.logger, on: request.eventLoop)
     }
 
     /// Downloads the resource.


### PR DESCRIPTION
EndpointCache's `get(on: Request)` convenience function was calling through directly to `download`, which was completely bypassing the cache. Updated this function to call through to `get(using: Client, on: EventLoop)` instead which should check cache correctly. 

Before this get merged, anyone else running into this can work around the bug by calling `cache.get(using: request.client, on: request.eventLoop)` instead of `cache.get(on: request)`