### PR TITLE
Pass session to cookie session factory allowing to modify cookie based on session data

### DIFF
--- a/Sources/Vapor/Sessions/SessionsConfiguration.swift
+++ b/Sources/Vapor/Sessions/SessionsConfiguration.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Configuration options for sessions.
 public struct SessionsConfiguration: Sendable {
     /// Creates a new `HTTPCookieValue` for the supplied value `String`.
-    public var cookieFactory: @Sendable (SessionID) -> HTTPCookies.Value
+    public var cookieFactory: @Sendable (SessionID, Session) -> HTTPCookies.Value
 
     /// Name of HTTP cookie, used as a key for the cookie value.
     public var cookieName: String
@@ -17,14 +17,14 @@ public struct SessionsConfiguration: Sendable {
     /// - parameters:
     ///     - cookieName: Name of HTTP cookie, used as a key for the cookie value.
     ///     - cookieFactory: Creates a new `HTTPCookieValue` for the supplied value `String`.
-    @preconcurrency public init(cookieName: String, cookieFactory: @Sendable @escaping (SessionID) -> HTTPCookies.Value) {
+    @preconcurrency public init(cookieName: String, cookieFactory: @Sendable @escaping (SessionID, Session) -> HTTPCookies.Value) {
         self.cookieName = cookieName
         self.cookieFactory = cookieFactory
     }
 
     /// `SessionsConfig` with basic cookie factory.
     public static func `default`() -> SessionsConfiguration {
-        return .init(cookieName: "vapor-session") { sessionID in
+        return .init(cookieName: "vapor-session") { sessionID, _ in
             return HTTPCookies.Value(
                 string: sessionID.string,
                 expires: Date(

--- a/Sources/Vapor/Sessions/SessionsMiddleware.swift
+++ b/Sources/Vapor/Sessions/SessionsMiddleware.swift
@@ -77,7 +77,7 @@ public final class SessionsMiddleware: Middleware {
             // After create or update, set cookie on the response.
             return createOrUpdate.map { id in
                 // the session has an id, set the cookie
-                response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id)
+                response.cookies[self.configuration.cookieName] = self.configuration.cookieFactory(id, session)
                 return response
             }
         } else if let cookieValue = request.cookies[self.configuration.cookieName] {


### PR DESCRIPTION
### Motivation

I was struggling to implement a “Remember me” feature for user login. Even after adding middleware like the snippet below, the SessionMiddleware kept overriding my cookie values.

```swift
struct ExtendSessionMiddleware<A: Authenticatable>: AsyncMiddleware {
    let authenticableType: A.Type

    init(authenticableType: A.Type) {
        self.authenticableType = authenticableType
    }

    func respond(to req: Request, chainingTo next: AsyncResponder) async throws -> Response {
        guard
            req.auth.has(authenticableType),
            let rememberMe = Bool(req.session.data["remeberMe"] ?? "")
        else { return try await next.respond(to: req) }

        let response = try await next.respond(to: req)

        let extendTime: TimeInterval = rememberMe ? 7 * 24 * 60 * 60 : 24 * 60 * 60
        let expiresAt = Date().addingTimeInterval(extendTime)

        let cookieName = req.application.sessions.configuration.cookieName
        if var cookie = req.cookies[cookieName] {
            cookie.expires = expiresAt
            cookie.maxAge = Int(extendTime)
            response.cookies[cookieName] = cookie
        }

        return response
    }
}
```

### Idea

My proposed solution is to pass the session itself to the cookie factory. This approach allows reading session values set during user login and overriding the default session behavior.

### Usage

```swift
var config = SessionsConfiguration.default()
config.cookieFactory = { sessionID, session in
    let rememberMe = Bool(session.data["remeberMe"] ?? "")
    let time: TimeInterval = (rememberMe ?? false) ? 7 * 24 * 60 * 60 : 24 * 60 * 60
    let expiresAt = Date().addingTimeInterval(time)
    return .init(string: sessionID.string, expires: expiresAt)
}
application.middleware.use(SessionsMiddleware(session: application.sessions.driver, configuration: config))
```

With this code, the session expires after one day if the user doesn’t select “Remember me,” and after seven days if they do.

### Question
Is there another way to solve this issue without requiring any changes from my PR?