### PR TITLE
test: fix `system` in internal classes

### DIFF
--- a/Tests/VaporTests/MetricsTests.swift
+++ b/Tests/VaporTests/MetricsTests.swift
@@ -7,7 +7,7 @@ import Testing
 @Suite("Metric Tests")
 struct MetricsTests {
     init() {
-        MetricsSystem.bootstrapInternal(TaskLocalMetricsSysemWrapper())
+        MetricsSystem.bootstrapInternal(TaskLocalMetricsSystemWrapper())
     }
 
     @Test("Test Metrics Increases Counter", .withMetrics(CapturingMetricsSystem("1")))

--- a/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
+++ b/Tests/VaporTests/Utilities/CapturingMetricsSystem.swift
@@ -18,7 +18,7 @@ import Metrics
 import Foundation
 import NIOConcurrencyHelpers
 
-internal final class TaskLocalMetricsSysemWrapper: MetricsFactory {
+internal final class TaskLocalMetricsSystemWrapper: MetricsFactory {
     func makeCounter(label: String, dimensions: [(String, String)]) -> any CoreMetrics.CounterHandler {
         metrics.makeCounter(label: label, dimensions: dimensions)
     }


### PR DESCRIPTION
Fixed all occurrences of `system` throughout the code. (Found only in tests)
All changes are backward compatible, as they are confined to internal-level code and do not affect the public API surface.