### PR TITLE
Add support for the “Partitioned” flag on HTTP cookies

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -144,6 +144,14 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
         /// This restriction mitigates attacks such as cross-site request forgery (XSRF).
         public var sameSite: SameSitePolicy?
         
+        /// Opt-In to “Cookies Having Independent Partitioned State”
+        ///
+        /// This allows developers to opt a cookie into partitioned storage, with a separate cookie jar per top-level site.
+        ///
+        /// Support for this feature is still fresh.
+        /// Notably, it has been added to Safari 18.4, then removed in 18.5 due to a [bug in underlying frameworks](<https://bugs.webkit.org/show_bug.cgi?id=292975#c15>).
+        public var partitioned: Bool
+        
         // MARK: Init
         
         /// Creates a new `HTTPCookieValue`.
@@ -167,7 +175,8 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
             path: String? = "/",
             isSecure: Bool = false,
             isHTTPOnly: Bool = false,
-            sameSite: SameSitePolicy? = .lax
+            sameSite: SameSitePolicy? = .lax,
+            partitioned: Bool = false
         ) {
             self.string = string
             self.expires = expires
@@ -180,6 +189,7 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
             self.isSecure = isSecure || forceSecure
             self.isHTTPOnly = isHTTPOnly
             self.sameSite = sameSite
+            self.partitioned = partitioned
         }
         
         /// See `ExpressibleByStringLiteral`.
@@ -227,6 +237,10 @@ public struct HTTPCookies: ExpressibleByDictionaryLiteral, Sendable {
                 case .none:
                     serialized += "=None"
                 }
+            }
+            
+            if self.partitioned {
+                serialized += "; Partitioned"
             }
             
             return serialized

--- a/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPCookies.swift
@@ -88,6 +88,8 @@ struct HTTPSetCookie {
                     return nil
                 }
                 self.value.sameSite = HTTPCookies.SameSitePolicy(rawValue: .init(parameter))
+            case "partitioned":
+                self.value.partitioned = true
             default:
                 return nil
             }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -145,7 +145,7 @@ final class HTTPHeaderTests: XCTestCase {
     func testComplexCookieParsing() throws {
         var headers = HTTPHeaders()
         do {
-            headers.add(name: .setCookie, value: "SIWA_STATE=CJKxa71djx6CaZ0MwRjtvtJ5Zub+kfaoIEZGoY3wXKA=; Path=/; SameSite=None; HttpOnly; Secure")
+            headers.add(name: .setCookie, value: "SIWA_STATE=CJKxa71djx6CaZ0MwRjtvtJ5Zub+kfaoIEZGoY3wXKA=; Path=/; SameSite=None; HttpOnly; Secure; Partitioned")
             headers.add(name: .setCookie, value: "vapor-session=TL7r+TS3RNhpEC6HoCfukq+7edNHKF2elF6WiKV4JCg=; Expires=Wed, 02 Jun 2021 14:57:57 GMT; Path=/; SameSite=None; HttpOnly; Secure")
             XCTAssertEqual(headers.setCookie?.all.count, 2)
             let siwaState = try XCTUnwrap(headers.setCookie?["SIWA_STATE"])
@@ -153,12 +153,14 @@ final class HTTPHeaderTests: XCTestCase {
             XCTAssertEqual(siwaState.expires, nil)
             XCTAssertTrue(siwaState.isHTTPOnly)
             XCTAssertTrue(siwaState.isSecure)
+            XCTAssertTrue(siwaState.partitioned)
 
             let vaporSession = try XCTUnwrap(headers.setCookie?["vapor-session"])
             XCTAssertEqual(vaporSession.sameSite, HTTPCookies.SameSitePolicy.none)
             XCTAssertEqual(vaporSession.expires, Date(timeIntervalSince1970: 1622645877))
             XCTAssertTrue(siwaState.isHTTPOnly)
             XCTAssertTrue(siwaState.isSecure)
+            XCTAssertFalse(vaporSession.partitioned)
         }
     }
 


### PR DESCRIPTION
Add possibility to set the “[Partitioned](<https://developer.mozilla.org/en-US/docs/Web/Privacy/Guides/Privacy_sandbox/Partitioned_cookies>)” flag on an HTTP cookie, also known as CHIPS (Cookies Having Independent Partitioned State).