### PR TITLE
Expose peer certificate in request handlers

### DIFF
--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1273,7 +1273,66 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         let a = try app.http.client.shared.execute(request: request).wait()
         XCTAssertEqual(a.body, ByteBuffer(string: "world"))
     }
-    
+
+    func testCanAccessPeerCertificate() throws {
+        guard let clientCertPath = Bundle.module.url(forResource: "expired", withExtension: "crt"),
+              let clientKeyPath = Bundle.module.url(forResource: "expired", withExtension: "key") else {
+            XCTFail("Cannot load expired cert and associated key")
+            return
+        }
+
+        let cert = try NIOSSLCertificate(file: clientCertPath.path, format: .pem)
+        let key = try NIOSSLPrivateKey(file: clientKeyPath.path, format: .pem)
+
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+
+        var serverConfig = TLSConfiguration.makeServerConfiguration(certificateChain: [.certificate(cert)], privateKey: .privateKey(key))
+        serverConfig.certificateVerification = .noHostnameVerification
+
+        app.http.server.configuration.tlsConfiguration = serverConfig
+        app.http.server.configuration.customCertificateVerifyCallback = { @Sendable peerCerts, successPromise in
+            // This lies and accepts the above cert, which has actually expired.
+            XCTAssertEqual(peerCerts, [cert])
+            successPromise.succeed(.certificateVerified)
+        }
+
+        // We need to disable verification on the client, because the cert we're using has expired, and we want to
+        // _send_ a client cert.
+        var clientConfig = TLSConfiguration.makeClientConfiguration()
+        clientConfig.certificateVerification = .none
+        clientConfig.certificateChain = [.certificate(cert)]
+        clientConfig.privateKey = .privateKey(key)
+        app.http.client.configuration.tlsConfiguration = clientConfig
+
+        app.environment.arguments = ["serve"]
+
+        app.get("hello") { req in
+            // The peer certificate should be available ...
+            XCTAssertNotNil(req.peerCertificate)
+            // ... and match the configured client certificate.
+            XCTAssertEqual(req.peerCertificate!, cert)
+            return "world"
+        }
+
+        try app.start()
+
+        XCTAssertNotNil(app.http.server.shared.localAddress)
+        guard let localAddress = app.http.server.shared.localAddress,
+              let ip = localAddress.ipAddress,
+              let port = localAddress.port else {
+            XCTFail("couldn't get ip/port from \(app.http.server.shared.localAddress.debugDescription)")
+            return
+        }
+
+        let request = try HTTPClient.Request(
+            url: "https://\(ip):\(port)/hello",
+            method: .GET
+        )
+        let a = try app.http.client.shared.execute(request: request).wait()
+        XCTAssertEqual(a.body, ByteBuffer(string: "world"))
+    }
+
     func testCanChangeConfigurationDynamically() throws {
         guard let clientCertPath = Bundle.module.url(forResource: "expired", withExtension: "crt"),
               let clientKeyPath = Bundle.module.url(forResource: "expired", withExtension: "key") else {


### PR DESCRIPTION
Additional certificate information can be relevant in mTLS deployments. Exposing the certificate makes this information available per request. The certificate will be nil if the client does not provide one.

Example usage:
```swift
app.get { req async in
    if let cert = req.peerCertificate {
        return "Your certificate is: \(cert.description)."
    } else {
        return "You provided no certificate."
    }
}
```