### PR TITLE
Fix test incompatibility with upcoming swift-nio changes

### DIFF
--- a/Tests/VaporTests/AsyncFileTests.swift
+++ b/Tests/VaporTests/AsyncFileTests.swift
@@ -53,7 +53,7 @@ final class AsyncFileTests: XCTestCase, @unchecked Sendable {
         app.get("file-stream") { req -> Response in
             var tmpPath: String
             repeat {
-                tmpPath = try await FileSystem.shared.temporaryDirectory.appending(UUID().uuidString).string
+                tmpPath = try await FilePath(FileSystem.shared.temporaryDirectory.description).appending(UUID().uuidString).string
             } while try await self.fileExists(at: tmpPath)
 
             return try await req.fileio.asyncStreamFile(at: tmpPath, advancedETagComparison: true) { result in


### PR DESCRIPTION
On current [swift-nio](https://github.com/apple/swift-nio) `main`, `NIOFileSystem`'s API no longer directly returns `FilePath`. This only affects Vapor in one place in one test; this PR fixes that one test.