### PR TITLE
Allow initializing Vapor.Application with a Logger

### DIFF
--- a/Tests/VaporTests/ApplicationCreationTests.swift
+++ b/Tests/VaporTests/ApplicationCreationTests.swift
@@ -1,0 +1,22 @@
+import Vapor
+import XCTVapor
+import XCTest
+
+final class ApplicationCreationTests: XCTestCase {
+    var app: Application!
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testCreateAsyncDefaultLogger() async throws {
+        app = try await Application.make(.testing)
+        XCTAssertEqual(app.logger.label, "codes.vapor.application")
+    }
+
+    func testCreateAsyncCustomLogger() async throws {
+        let logger = Logger(label: "custom")
+        app = try await Application.make(.testing, logger: logger)
+        XCTAssertEqual(app.logger.label, "custom")
+    }
+}


### PR DESCRIPTION
**These changes are now available in [4.116.0](https://github.com/vapor/vapor/releases/tag/4.116.0)**


When using a single Logger in the whole app, it's useful to be able to initialize the Vapor app with one as well, rather than letting it create one internally.

This doesn't change behavior for existing users, just adds a new variant of the `Vapor.Application.make` method that takes a Logger explicitly.

Added unit tests to cover both the default and the new option.