### PR TITLE
Add HEIC (HEVC in HEIF) HTTPMediaType Support

### DIFF
--- a/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPMediaType.swift
@@ -281,6 +281,8 @@ public extension HTTPMediaType {
     static let jxl = HTTPMediaType(type: "image", subType: "jxl")
     /// AVIF image.
     static let avif = HTTPMediaType(type: "image", subType: "avif")
+    /// HEIC (HEVC in HEIF) image
+    static let heic = HTTPMediaType(type: "image", subType: "heic")
     /// Basic audio.
     static let audio = HTTPMediaType(type: "audio", subType: "basic")
     /// MIDI audio.
@@ -700,6 +702,7 @@ let fileExtensionMediaTypeMapping: [String: HTTPMediaType] = [
     "webp": HTTPMediaType.webp,
     "jxl": HTTPMediaType.jxl,
     "avif": HTTPMediaType.avif,
+    "heic": HTTPMediaType.heic,
     "djvu": HTTPMediaType(type: "image", subType: "vnd.djvu"),
     "djv": HTTPMediaType(type: "image", subType: "vnd.djvu"),
     "ico": HTTPMediaType(type: "image", subType: "vnd.microsoft.icon"),
@@ -908,6 +911,7 @@ extension HTTPMediaTypeSet {
         HTTPMediaType.webp,
         HTTPMediaType.jxl,
         HTTPMediaType.avif,
+        HTTPMediaType.heic,
         HTTPMediaType(type: "image", subType: "vnd.djvu"),
         HTTPMediaType(type: "image", subType: "vnd.microsoft.icon"),
         HTTPMediaType(type: "image", subType: "vnd.wap.wbmp"),


### PR DESCRIPTION
**These changes are now available in [4.117.1](https://github.com/vapor/vapor/releases/tag/4.117.1)**


Add the HTTP media type for HEIC/HEIF images to HTTPMediaType, as Safari 17+ supports this format.