### PR TITLE
Explicitly import CNIOLinux module

### DIFF
--- a/Sources/Vapor/Utilities/String+IsIPAddress.swift
+++ b/Sources/Vapor/Utilities/String+IsIPAddress.swift
@@ -1,5 +1,7 @@
 import Foundation
+#if canImport(CNIOLinux)
 import CNIOLinux
+#endif
 #if canImport(Android)
 import Android
 #endif


### PR DESCRIPTION
Fix "error: initializer 'init()' is not available due to missing import of defining module 'CNIOLinux'" errors when compiling on Linux.