### PR TITLE
Allow unicode routes

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -91,7 +91,7 @@ package struct DefaultResponder: Responder {
     private func getRoute(for request: Request) -> CachedRoute? {
         let pathComponents = request.url.path
             .split(separator: "/")
-            .map(String.init)
+            .map { String($0).removingPercentEncoding ?? String($0) }  
         
         // If it's a HEAD request and a HEAD route exists, return that route...
         if request.method == .head, let route = self.router.route(

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -494,4 +494,27 @@ struct RouteTests {
             }
         }
     }
+
+    @Test("Unicode Routing", .bug("https://github.com/vapor/vapor/issues/3309"))
+    func unicodeRouting() async throws {
+        try await withApp { app in
+            app.get("Good👍") { req in
+                return "👍"
+            }
+            app.get("ようこそ世界へ") { req in
+                return "おめでとう"
+            }
+
+            try await app.test(method: .running) { testApp in
+                let emoticon = try await testApp.sendRequest(.get, "/Good👍")
+                #expect(emoticon.body.string == "👍")
+                #expect(emoticon.status == .ok)
+
+                let japanese = try await testApp.sendRequest(.get, "/ようこそ世界へ")
+                #expect(japanese.body.string == "おめでとう")
+                #expect(japanese.status == .ok)
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Closes #3309

We should allow unicode routes to be registered. To do this, we can simply attempt to percent-decode routes when they come in