### PR TITLE
Fix compatibility with swift-log 1.8.0 and later

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,7 +43,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.24.0"),
 
         // Swift logging API
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.8.0"),
 
         // Swift metrics API
         .package(url: "https://github.com/apple/swift-metrics.git", from: "2.5.0"),

--- a/Sources/Vapor/Logging/LoggingSystem+Environment.swift
+++ b/Sources/Vapor/Logging/LoggingSystem+Environment.swift
@@ -20,13 +20,7 @@ extension LoggingSystem {
     }
 }
 
-extension Logger.Level: @retroactive CustomStringConvertible {}
-extension Logger.Level: @retroactive LosslessStringConvertible {}
-
 extension Logging.Logger.Level {
-    public init?(_ description: String) { self.init(rawValue: description.lowercased()) }
-    public var description: String { self.rawValue }
-
     public static func detect(from environment: inout Environment) throws -> Logger.Level {
         struct LogSignature: CommandSignature {
             @Option(name: "log", help: "Change log level")


### PR DESCRIPTION
**These changes are now available in [4.120.0](https://github.com/vapor/vapor/releases/tag/4.120.0)**


[swift-log](https://github.com/apple/swift-log) introduced `CustomStringConvertible` and `LosslessStringConvertible` conformances on `Logger.Level` which cause build errors by conflicting with our implementations, so ours are now gone.