### PR TITLE
Instantiate request storage with same request logger (#2489)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -184,6 +184,7 @@ let package = Package(
                 .target(name: "Vapor"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "InMemoryLogging", package: "swift-log"),
             ],
             resources: [
                 .copy("Utilities/foo.txt"),

--- a/Sources/Vapor/Request/Request.swift
+++ b/Sources/Vapor/Request/Request.swift
@@ -364,7 +364,7 @@ public final class Request: CustomStringConvertible, Sendable {
         self.application = application
         
         self.remoteAddress = remoteAddress
-        self._storage = .init(.init())
+        self._storage = .init(.init(logger: logger))
         self.bodyStorage = .init(bodyStorage)
         self.newBodyStorage = .init(nil)
     }


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
## Description
Implements #2489 - Request's Storage logger now uses Request's logger.

## Solution
Changed `Request` initialization to pass the request's logger to the internal `Storage` object.

**Before:**
```swift
self._storage = .init(.init())
```
**After:**
```swift
self._storage = .init(.init(logger: logger))
```

## Testing
Added testStorageUsesRequestLogger.swift:

1: Creates a request with a custom logger (and InMemoryLogHandler)
2: Stores a value with a shutdown handler that throws
3: Verifies the logged error contains the request's request-id metadata, so that we know it's using the same logger as the Request itself.
4: Uses InMemoryLogHandler to inspect logs without exposing internal fields. See: [https://github.com/apple/swift-log/pull/390](https://github.com/apple/swift-log/pull/390)