### PR TITLE
Add Sendable conformance to application testing Method type

### DIFF
--- a/Sources/VaporTestUtils/TestingApplication.swift
+++ b/Sources/VaporTestUtils/TestingApplication.swift
@@ -2,7 +2,7 @@ import AsyncHTTPClient
 import Vapor
 
 extension Application {
-    public enum Method {
+    public enum Method: Sendable {
         case inMemory
         // TODO: Default to Port 0 in the next major release
         public static var running: Method {


### PR DESCRIPTION
**These changes are now available in [4.121.2](https://github.com/vapor/vapor/releases/tag/4.121.2)**


This PR adds `Sendable` conformance to the `Method` type in the `VaporTestUtils` target.