### PR TITLE
Include request URL in RouteNotFound error

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -137,16 +137,24 @@ internal struct DefaultResponder: Responder {
 
 private struct NotFoundResponder: Responder {
     func respond(to request: Request) -> EventLoopFuture<Response> {
-        request.eventLoop.makeFailedFuture(RouteNotFound())
+        request.eventLoop.makeFailedFuture(RouteNotFound(route: request.url.string))
     }
 }
 
-public struct RouteNotFound: Error {}
+public struct RouteNotFound: Error, CustomStringConvertible {
+    public let route: String
+
+    public var description: String {
+        "No route found for \"\(route)\""
+    }
+}
 
 extension RouteNotFound: AbortError {
     public var status: HTTPResponseStatus {
         .notFound
     }
+
+    public var reason: String { description }
 }
 
 extension RouteNotFound: DebuggableError {


### PR DESCRIPTION
## Summary

- Update `RouteNotFound` to include the request URL that triggered the 404
- Add `CustomStringConvertible` conformance with descriptive message: `No route found for "/path"`
- Add `reason` property to the `AbortError` conformance so the URL appears in error responses

Closes #3237

## Changes

- `NotFoundResponder` now passes `request.url.string` to `RouteNotFound`
- `RouteNotFound` gains a `route: String` property
- Error messages now include the missing route for easier debugging

## Test plan

- [ ] Existing tests pass
- [ ] 404 errors now include the requested URL in the error message
- [ ] Logs show which specific route was not found

🤖 Generated with [Claude Code](https://claude.com/claude-code)