### PR TITLE
Include request method and path in RouteNotFound error

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -137,15 +137,30 @@ internal struct DefaultResponder: Responder {
 
 private struct NotFoundResponder: Responder {
     func respond(to request: Request) -> EventLoopFuture<Response> {
-        request.eventLoop.makeFailedFuture(RouteNotFound())
+        request.eventLoop.makeFailedFuture(RouteNotFound(method: request.method, path: request.url.path))
     }
 }
 
-public struct RouteNotFound: Error {}
+public struct RouteNotFound: Error {
+    /// The HTTP method of the request that was not found.
+    public let method: HTTPMethod
+
+    /// The path of the request that was not found.
+    public let path: String
+
+    public init(method: HTTPMethod = .GET, path: String = "/") {
+        self.method = method
+        self.path = path
+    }
+}
 
 extension RouteNotFound: AbortError {
     public var status: HTTPResponseStatus {
         .notFound
+    }
+
+    public var reason: String {
+        "Route not found for \(self.method) \(self.path)"
     }
 }
 


### PR DESCRIPTION
## Summary

The `RouteNotFound` error previously provided no context about which URL triggered the 404, making routing issues hard to debug.

## Changes

- Added `method` and `path` properties to `RouteNotFound`
- Added a descriptive `reason` (e.g., `Route not found for GET /api/users/123`)
- Default initializer preserves backward compatibility

## Fixes

- Fixes #3237