### PR TITLE
Add `contains` method to `URLQueryContainer`

### DIFF
--- a/Sources/Vapor/Content/URLQueryContainer.swift
+++ b/Sources/Vapor/Content/URLQueryContainer.swift
@@ -79,6 +79,22 @@ extension URLQueryContainer {
         try self.get(D.self, path: path.map(\.codingKey))
     }
 
+    // MARK: - Existence check
+
+    /// Check whether a query parameter exists at the supplied keypath.
+    ///
+    ///     if req.query.contains("page") { ... }
+    public func contains(_ path: CodingKeyRepresentable...) -> Bool {
+        self.contains(at: path)
+    }
+
+    /// Check whether a query parameter exists at the supplied keypath.
+    ///
+    ///     if req.query.contains(at: ["user", "name"]) { ... }
+    public func contains(at path: [CodingKeyRepresentable]) -> Bool {
+        (try? self.get(String.self, at: path)) != nil
+    }
+
     // MARK: Private
 
     /// Execute a "get at coding key path" operation.

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -312,6 +312,15 @@ final class QueryTests: XCTestCase {
         XCTAssertNil(try req.query.decode(OptionalBarStruct.self).bar)
     }
     
+    func testContains() throws {
+        let request = Request(application: app, on: app.eventLoopGroup.next())
+        request.url = .init(path: "/foo?page=1&empty=&flag")
+
+        XCTAssertTrue(request.query.contains("page"))
+        XCTAssertTrue(request.query.contains("empty"))
+        XCTAssertFalse(request.query.contains("missing"))
+    }
+
     func testNotCrashingWhenUnkeyedContainerIsAtEnd() {
         struct Query: Decodable {
             let closedRange: ClosedRange<Double>


### PR DESCRIPTION
## Description

Adds `contains(_:)` and `contains(at:)` methods to `URLQueryContainer` to check whether a query parameter exists at a given keypath without needing to decode its value.

This addresses a common pattern where you only care about presence, not value:

```swift
// Before: awkward workaround
let hasPage = (try? req.query.get(String.self, at: "page")) != nil

// After: clean and readable
if req.query.contains("page") { ... }
```

Both variadic and array-based keypaths are supported, consistent with the existing `get` API.

## Changes
- Added `contains(_: CodingKeyRepresentable...)` — variadic keypath check
- Added `contains(at: [CodingKeyRepresentable])` — array keypath check
- Added test in `QueryTests.swift`

Closes #3343