### PR TITLE
Add contains method to URLQueryContainer

### DIFF
--- a/Sources/Vapor/Content/URLQueryContainer.swift
+++ b/Sources/Vapor/Content/URLQueryContainer.swift
@@ -79,7 +79,31 @@ extension URLQueryContainer {
         try self.get(D.self, path: path.map(\.codingKey))
     }
 
+    // MARK: - Contains helpers
+
+    /// Check whether a value exists at the supplied keypath in the container.
+    ///
+    ///     if req.query.contains("foo") { ... }
+    public func contains(_ path: CodingKeyRepresentable...) -> Bool {
+        self.contains(path)
+    }
+
+    /// Check whether a value exists at the supplied keypath in the container.
+    ///
+    ///     if req.query.contains(["user", "name"]) { ... }
+    public func contains(_ path: [CodingKeyRepresentable]) -> Bool {
+        self.hasKey(at: path.map(\.codingKey))
+    }
+
     // MARK: Private
+
+    /// Execute a "has key at coding key path" operation.
+    private func hasKey(at path: [CodingKey]) -> Bool {
+        (try? self.decode(ContainerHasKeyExecutor.self, using: ForwardingURLQueryDecoder(
+            base: self.configuredDecoder(),
+            info: ContainerHasKeyExecutor.userInfo(for: path)
+        )).result) ?? false
+    }
 
     /// Execute a "get at coding key path" operation.
     private func get<D: Decodable>(_: D.Type = D.self, path: [CodingKey]) throws -> D {

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -312,6 +312,54 @@ final class QueryTests: XCTestCase {
         XCTAssertNil(try req.query.decode(OptionalBarStruct.self).bar)
     }
     
+    func testContainsKey() throws {
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/path?foo=a&bar=b"),
+            on: app.eventLoopGroup.next()
+        )
+
+        XCTAssertTrue(req.query.contains("foo"))
+        XCTAssertTrue(req.query.contains("bar"))
+        XCTAssertFalse(req.query.contains("baz"))
+    }
+
+    func testContainsValuelessKey() throws {
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/path?flag"),
+            on: app.eventLoopGroup.next()
+        )
+
+        XCTAssertTrue(req.query.contains("flag"))
+        XCTAssertFalse(req.query.contains("other"))
+    }
+
+    func testContainsNoQuery() throws {
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/path"),
+            on: app.eventLoopGroup.next()
+        )
+
+        XCTAssertFalse(req.query.contains("foo"))
+    }
+
+    func testContainsNestedKey() throws {
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/path?user[name]=Vapor"),
+            on: app.eventLoopGroup.next()
+        )
+
+        XCTAssertTrue(req.query.contains("user", "name"))
+        XCTAssertFalse(req.query.contains("user", "age"))
+    }
+
     func testNotCrashingWhenUnkeyedContainerIsAtEnd() {
         struct Query: Decodable {
             let closedRange: ClosedRange<Double>


### PR DESCRIPTION
## Summary
- Adds a non-throwing `contains(_:)` method to `URLQueryContainer` that checks whether a key exists in the query string without needing to decode its value
- Supports both simple keys (`req.query.contains("foo")`) and nested keypaths (`req.query.contains("user", "name")`)
- Works with valueless/flag-style query parameters (e.g. `?verbose`)

Resolves #3343

## Implementation
- Introduces `ContainerHasKeyExecutor`, a lightweight `Decodable` struct that uses `KeyedDecodingContainer.contains(_:)` to check for key presence without decoding values
- Follows the same keypath traversal pattern used by the existing `ContainerGetPathExecutor`
- The method is non-throwing and returns `false` when the decoder itself fails (e.g. no query string present)

## Test plan
- [x] `testContainsKey` - verifies basic key presence/absence with `?foo=a&bar=b`
- [x] `testContainsValuelessKey` - verifies valueless/flag params like `?flag`
- [x] `testContainsNoQuery` - verifies `false` when URL has no query string
- [x] `testContainsNestedKey` - verifies nested keys like `?user[name]=Vapor`

🤖 Generated with [Claude Code](https://claude.com/claude-code)