### PR TITLE
Add `has` method to URLQueryContainer

### DIFF
--- a/Sources/Vapor/Content/URLQueryContainer.swift
+++ b/Sources/Vapor/Content/URLQueryContainer.swift
@@ -79,6 +79,26 @@ extension URLQueryContainer {
         try self.get(D.self, path: path.map(\.codingKey))
     }
 
+    // MARK: - Existence check
+
+    /// Check whether a value exists at the given key path in the query string.
+    ///
+    ///     if req.query.has("page") {
+    ///         let page = try req.query.get(Int.self, at: "page")
+    ///     }
+    public func has(_ path: CodingKeyRepresentable...) -> Bool {
+        self.has(path)
+    }
+
+    /// Check whether a value exists at the given key path in the query string.
+    ///
+    ///     if req.query.has(["user", "name"]) {
+    ///         let name = try req.query.get(String.self, at: ["user", "name"])
+    ///     }
+    public func has(_ path: [CodingKeyRepresentable]) -> Bool {
+        self[String.self, at: path] != nil
+    }
+
     // MARK: Private
 
     /// Execute a "get at coding key path" operation.

--- a/Tests/VaporTests/QueryTests.swift
+++ b/Tests/VaporTests/QueryTests.swift
@@ -312,6 +312,35 @@ final class QueryTests: XCTestCase {
         XCTAssertNil(try req.query.decode(OptionalBarStruct.self).bar)
     }
     
+    func testHas() throws {
+        let req = Request(
+            application: app,
+            method: .GET,
+            url: URI(string: "/"),
+            on: app.eventLoopGroup.next()
+        )
+
+        // Key with value
+        req.url = .init(path: "/foo?bar=baz&page=1")
+        XCTAssertTrue(req.query.has("bar"))
+        XCTAssertTrue(req.query.has("page"))
+        XCTAssertFalse(req.query.has("missing"))
+
+        // No query string
+        req.url = .init(path: "/foo")
+        XCTAssertFalse(req.query.has("bar"))
+
+        // Nested key path
+        req.url = .init(path: "/foo?user[name]=Vapor")
+        XCTAssertTrue(req.query.has("user", "name"))
+        XCTAssertFalse(req.query.has("user", "age"))
+
+        // Array key path overload
+        req.url = .init(path: "/foo?a=1")
+        XCTAssertTrue(req.query.has(["a"]))
+        XCTAssertFalse(req.query.has(["b"]))
+    }
+
     func testNotCrashingWhenUnkeyedContainerIsAtEnd() {
         struct Query: Decodable {
             let closedRange: ClosedRange<Double>


### PR DESCRIPTION
## Summary

Adds a `has` method to `URLQueryContainer` that checks whether a query parameter exists at a given key path, without requiring type information.

- Variadic overload: `req.query.has("page")`
- Array overload: `req.query.has(["user", "name"])`
- Leverages existing subscript infrastructure (`self[String.self, at: path] != nil`)

Closes #3343

## Example

```swift
app.get("search") { req in
    if req.query.has("page") {
        let page = try req.query.get(Int.self, at: "page")
        // ...
    }
}
```

## Test plan

- [x] Key with value returns `true`
- [x] Missing key returns `false`
- [x] No query string returns `false`
- [x] Nested key path support
- [x] Array key path overload
- [ ] @0xLeif review

🤖 Generated with [Claude Code](https://claude.com/claude-code)