### PR TITLE
Add generic Registry<ID, Value> type

### DIFF
--- a/Sources/Vapor/Utilities/Application+Registry.swift
+++ b/Sources/Vapor/Utilities/Application+Registry.swift
@@ -1,0 +1,59 @@
+import NIOConcurrencyHelpers
+
+extension Application {
+    public func registry<ID: Hashable & Sendable, Value: Sendable>(for name: String) -> Registry<ID, Value> {
+        self.registries.get(name)
+    }
+
+    var registries: Registries {
+        .init(application: self)
+    }
+
+    struct Registries: Sendable {
+        final class Storage: Sendable {
+            let registries: NIOLockedValueBox<[String: any Sendable]>
+            init() {
+                self.registries = .init([:])
+            }
+        }
+
+        struct Key: StorageKey {
+            typealias Value = Storage
+        }
+
+        let application: Application
+
+        var storage: Storage {
+            if let existing = self.application.storage[Key.self] {
+                return existing
+            }
+            let new = Storage()
+            self.application.storage[Key.self] = new
+            return new
+        }
+
+        func get<ID: Hashable & Sendable, Value: Sendable>(_ name: String) -> Registry<ID, Value> {
+            self.storage.registries.withLockedValue { dict in
+                if let existing = dict[name] {
+                    guard let typed = existing as? Registry<ID, Value> else {
+                        fatalError(
+                            "Registry '\(name)' already exists with a different type. "
+                            + "Expected Registry<\(ID.self), \(Value.self)>, "
+                            + "found \(type(of: existing))."
+                        )
+                    }
+                    return typed
+                }
+                let new = Registry<ID, Value>()
+                dict[name] = new
+                return new
+            }
+        }
+    }
+}
+
+extension Request {
+    public func registry<ID: Hashable & Sendable, Value: Sendable>(for name: String) -> Registry<ID, Value> {
+        self.application.registry(for: name)
+    }
+}

--- a/Sources/Vapor/Utilities/Registry.swift
+++ b/Sources/Vapor/Utilities/Registry.swift
@@ -1,0 +1,70 @@
+import NIOConcurrencyHelpers
+
+/// A thread-safe, generic collection of values keyed by ID.
+public final class Registry<ID: Hashable & Sendable, Value: Sendable>: Sendable {
+    private let entries: NIOLockedValueBox<[ID: Value]>
+
+    public init() {
+        self.entries = .init([:])
+    }
+
+    public func register(_ id: ID, _ value: Value) {
+        self.entries.withLockedValue { $0[id] = value }
+    }
+
+    @discardableResult
+    public func remove(_ id: ID) -> Value? {
+        self.entries.withLockedValue { $0.removeValue(forKey: id) }
+    }
+
+    public subscript(id: ID) -> Value? {
+        self.entries.withLockedValue { $0[id] }
+    }
+
+    public var all: [ID: Value] {
+        self.entries.withLockedValue { $0 }
+    }
+
+    public var count: Int {
+        self.entries.withLockedValue { $0.count }
+    }
+
+    public var isEmpty: Bool {
+        self.entries.withLockedValue { $0.isEmpty }
+    }
+
+    public func contains(_ id: ID) -> Bool {
+        self.entries.withLockedValue { $0[id] != nil }
+    }
+
+    /// Throws ``RegistryError/notFound`` if no value exists for the given ID.
+    public func send(to id: ID, _ action: @Sendable (Value) async throws -> Void) async throws {
+        guard let value = self[id] else {
+            throw RegistryError.notFound
+        }
+        try await action(value)
+    }
+
+    /// Snapshots the registry before iterating so mutations during iteration are safe.
+    public func broadcast(_ action: @Sendable (Value) async throws -> Void) async throws {
+        let snapshot = self.all
+        for value in snapshot.values {
+            try await action(value)
+        }
+    }
+
+    public func clear() {
+        self.entries.withLockedValue { $0.removeAll() }
+    }
+}
+
+public enum RegistryError: Error, CustomStringConvertible {
+    case notFound
+
+    public var description: String {
+        switch self {
+        case .notFound:
+            return "Registry entry not found for the given ID."
+        }
+    }
+}

--- a/Tests/VaporTests/RegistryTests.swift
+++ b/Tests/VaporTests/RegistryTests.swift
@@ -1,0 +1,184 @@
+import HTTPTypes
+import NIOConcurrencyHelpers
+import RoutingKit
+import Testing
+import Vapor
+import VaporTesting
+
+@Suite("Registry Tests")
+struct RegistryTests {
+    @Test("Register and retrieve values")
+    func registerAndRetrieve() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+        registry.register("b", 2)
+
+        #expect(registry["a"] == 1)
+        #expect(registry["b"] == 2)
+        #expect(registry["c"] == nil)
+        #expect(registry.count == 2)
+    }
+
+    @Test("Remove values")
+    func removeValues() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+        registry.register("b", 2)
+
+        let removed = registry.remove("a")
+        #expect(removed == 1)
+        #expect(registry["a"] == nil)
+        #expect(registry.count == 1)
+
+        let notFound = registry.remove("nonexistent")
+        #expect(notFound == nil)
+    }
+
+    @Test("Replace existing value")
+    func replaceExisting() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+        registry.register("a", 42)
+
+        #expect(registry["a"] == 42)
+        #expect(registry.count == 1)
+    }
+
+    @Test("All returns snapshot")
+    func allSnapshot() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+        registry.register("b", 2)
+
+        let snapshot = registry.all
+        #expect(snapshot == ["a": 1, "b": 2])
+    }
+
+    @Test("Contains check")
+    func contains() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+
+        #expect(registry.contains("a"))
+        #expect(!registry.contains("b"))
+    }
+
+    @Test("isEmpty and clear")
+    func isEmptyAndClear() async throws {
+        let registry = Registry<String, Int>()
+        #expect(registry.isEmpty)
+
+        registry.register("a", 1)
+        #expect(!registry.isEmpty)
+
+        registry.clear()
+        #expect(registry.isEmpty)
+        #expect(registry.count == 0)
+    }
+
+    @Test("Send to specific entry")
+    func sendToEntry() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 42)
+
+        let received = NIOLockedValueBox(0)
+        try await registry.send(to: "a") { value in
+            received.withLockedValue { $0 = value }
+        }
+        #expect(received.withLockedValue { $0 } == 42)
+    }
+
+    @Test("Send to missing entry throws notFound")
+    func sendToMissing() async throws {
+        let registry = Registry<String, Int>()
+
+        await #expect(throws: RegistryError.notFound) {
+            try await registry.send(to: "missing") { _ in }
+        }
+    }
+
+    @Test("Broadcast to all entries")
+    func broadcast() async throws {
+        let registry = Registry<String, Int>()
+        registry.register("a", 1)
+        registry.register("b", 2)
+        registry.register("c", 3)
+
+        let collected = NIOLockedValueBox<[Int]>([])
+        try await registry.broadcast { value in
+            collected.withLockedValue { $0.append(value) }
+        }
+
+        let result = collected.withLockedValue { $0.sorted() }
+        #expect(result == [1, 2, 3])
+    }
+
+    @Test("Application registry returns same instance")
+    func applicationRegistrySameInstance() async throws {
+        try await withApp { app in
+            let reg1: Registry<String, Int> = app.registry(for: "test")
+            let reg2: Registry<String, Int> = app.registry(for: "test")
+
+            reg1.register("key", 42)
+            #expect(reg2["key"] == 42)
+            #expect(reg1 === reg2)
+        }
+    }
+
+    @Test("Application registries with different names are independent")
+    func applicationRegistriesIndependent() async throws {
+        try await withApp { app in
+            let reg1: Registry<String, Int> = app.registry(for: "one")
+            let reg2: Registry<String, Int> = app.registry(for: "two")
+
+            reg1.register("key", 1)
+            reg2.register("key", 2)
+
+            #expect(reg1["key"] == 1)
+            #expect(reg2["key"] == 2)
+            #expect(reg1 !== reg2)
+        }
+    }
+
+    @Test("Request registry forwards to application")
+    func requestRegistryForwards() async throws {
+        try await withApp { app in
+            let appRegistry: Registry<String, Int> = app.registry(for: "shared")
+            appRegistry.register("key", 99)
+
+            app.get("test") { req in
+                let reqRegistry: Registry<String, Int> = req.registry(for: "shared")
+                return String(reqRegistry["key"] ?? -1)
+            }
+
+            try await app.testing().test(.get, "test") { res in
+                #expect(res.body.string == "99")
+            }
+        }
+    }
+
+    @Test("Concurrent access is safe")
+    func concurrentAccess() async throws {
+        let registry = Registry<Int, String>()
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<100 {
+                group.addTask {
+                    registry.register(i, "value-\(i)")
+                }
+            }
+        }
+
+        #expect(registry.count == 100)
+
+        await withTaskGroup(of: Void.self) { group in
+            for i in 0..<50 {
+                group.addTask {
+                    registry.remove(i)
+                }
+            }
+        }
+
+        #expect(registry.count == 50)
+    }
+}


### PR DESCRIPTION
## Summary

Adds `Registry<ID, Value>`, a thread-safe generic container for managing keyed collections, with `Application.registry(for:)` and `Request.registry(for:)` for lazy named access.

### Before

```swift
extension Application {
    struct MyService: Sendable {
        final class Storage: Sendable {
            struct Factory { ... }
            let connections: NIOLockedValueBox<[UUID: WebSocket]>
            // ...
        }
        struct Key: StorageKey {
            typealias Value = Storage
        }
        var storage: Storage {
            guard let storage = self.application.storage[Key.self] else {
                fatalError("Not configured...")
            }
            return storage
        }
        func initialize() { ... }
    }
}
```

### After

```swift
extension Application {
    var chatSockets: Registry<UUID, WebSocket> {
        self.registry(for: "chat")
    }
}
```

### Usage

```swift
app.webSocket("chat") { req, ws in
    let id = UUID()
    req.application.chatSockets.register(id, ws)
    defer { req.application.chatSockets.remove(id) }

    for await message in ws.messages {
        try await handleMessage(message, from: id, req: req)
    }
}