### PR TITLE
Add stored contentType to File

### DIFF
--- a/Sources/Vapor/Multipart/File+Multipart.swift
+++ b/Sources/Vapor/Multipart/File+Multipart.swift
@@ -6,9 +6,7 @@ import NIOCore
 extension File: MultipartPartConvertible {
     public var multipart: MultipartPart<ByteBufferView>? {
         var part = MultipartPart(headerFields: [:], body: self.data.readableBytesView)
-        part.contentType = self.extension
-            .flatMap { HTTPMediaType.fileExtension($0) }
-            .flatMap { $0.serialize() }
+        part.contentType = self.contentType?.serialize()
         part.filename = self.filename
         return part
     }
@@ -17,7 +15,8 @@ extension File: MultipartPartConvertible {
         guard let filename = multipart.filename else {
             return nil
         }
-        self.init(data: ByteBuffer(bytes: multipart.body), filename: filename)
+        let contentType = multipart.headerFields.contentType
+        self.init(data: ByteBuffer(bytes: multipart.body), filename: filename, contentType: contentType)
     }
 }
 

--- a/Sources/Vapor/Utilities/File.swift
+++ b/Sources/Vapor/Utilities/File.swift
@@ -9,11 +9,14 @@ public struct File: Codable, Equatable, Sendable {
     
     /// The file's data.
     public var data: ByteBuffer
-    
-    /// Associated `MediaType` for this file's extension, if it has one.
+
+    /// Associated `MediaType` for this file, preferring the explicitly set value, falling back to the file extension.
     public var contentType: HTTPMediaType? {
-        return self.extension.flatMap { HTTPMediaType.fileExtension($0.lowercased()) }
+        get { _contentType ?? self.extension.flatMap { HTTPMediaType.fileExtension($0.lowercased()) } }
+        set { _contentType = newValue }
     }
+
+    private var _contentType: HTTPMediaType?
     
     /// The file extension, if it has one.
     public var `extension`: String? {
@@ -57,9 +60,9 @@ public struct File: Codable, Equatable, Sendable {
     /// - parameters:
     ///     - data: The file's contents.
     ///     - filename: The name of the file, not including path.
-    public init(data: String, filename: String) {
+    public init(data: String, filename: String, contentType: HTTPMediaType? = nil) {
         let buffer = ByteBufferAllocator().buffer(string: data)
-        self.init(data: buffer, filename: filename)
+        self.init(data: buffer, filename: filename, contentType: contentType)
     }
     
     /// Creates a new `File`.
@@ -69,8 +72,9 @@ public struct File: Codable, Equatable, Sendable {
     /// - parameters:
     ///     - data: The file's contents.
     ///     - filename: The name of the file, not including path.
-    public init(data: ByteBuffer, filename: String) {
+    public init(data: ByteBuffer, filename: String, contentType: HTTPMediaType? = nil) {
         self.data = data
         self.filename = filename
+        self._contentType = contentType
     }
 }

--- a/Tests/VaporTests/ContentTests.swift
+++ b/Tests/VaporTests/ContentTests.swift
@@ -358,6 +358,39 @@ struct ContentTests {
             }
         }
     }
+    
+    @Test("Multipart File prefers header contentType", .bug("https://github.com/vapor/vapor/issues/2571"))
+    func testMultipartFileContentTypeUsesHeader() async throws {
+        // A file named "your-face.jpg" but with Content-Type: image/webp
+        // The decoded File.contentType should be image/webp, not image/jpeg
+        let data = """
+        --123\r
+        Content-Disposition: form-data; name="upload"; filename="your-face.jpg"\r
+        Content-Type: image/webp\r
+        \r
+        1234\r
+        --123--\r\n
+        """
+
+        struct Payload: Content {
+            let upload: File
+        }
+
+        try await withApp { app in
+            app.routes.get("multipart") { req -> String in
+                let payload = try await req.content.decode(Payload.self)
+                #expect(payload.upload.filename == "your-face.jpg")
+                #expect(payload.upload.contentType == .webp)
+                return "ok"
+            }
+
+            try await app.testing().test(.get, "/multipart", headers: [
+                .contentType: "multipart/form-data; boundary=123"
+            ], body: .init(string: data)) { res in
+                #expect(res.status == .ok)
+            }
+        }
+    }
     #endif
 
     @Test("Test URLEncoded Form Decode")


### PR DESCRIPTION
Fixes #2571 

Instead of computing the content type from the extension, we can and should parse the header's content type and prefer that to the extension one, if present.