### PR TITLE
Fix Response Compression Bug when Content Type header is empty

### DIFF
--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -801,10 +801,11 @@ extension HTTPServer.Configuration.ResponseCompressionConfiguration {
                 return shouldDisable ? .doNotCompress : .compressIfPossible
             case .disabled(_, let allowedTypes, _):
                 /// If there were no explicit overrides, fallback to checking the content type against the allowed set. If all types succeed the check, enable compression:
-                let shouldEnable = responseHeaders.headers.parseDirectives(name: .contentType).allSatisfy { contentTypeDirectives in
+                let contentTypeDirectives = responseHeaders.headers.parseDirectives(name: .contentType)
+                let shouldEnable = !contentTypeDirectives.isEmpty && contentTypeDirectives.allSatisfy { contentTypeDirectives in
                     guard let mediaType = HTTPMediaType(directives: contentTypeDirectives)
                     else { return false }
-                    
+
                     return allowedTypes.contains(mediaType)
                 }
                 

--- a/Tests/VaporTests/ConditionalResponseCompressionTests.swift
+++ b/Tests/VaporTests/ConditionalResponseCompressionTests.swift
@@ -319,6 +319,34 @@ final class ConditionalResponseCompressionServerTests: XCTestCase, @unchecked Se
         try await assertUncompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
     }
     
+    func testMissingContentType() async throws {
+        app.get("resource") { request in
+            Response(status: .ok, body: .init(string: compressiblePayload))
+        }
+
+        try app.server.start()
+
+        try await assertUncompressed(app.http.server.configuration.responseCompression) /// Default case
+        try await assertUncompressed(.forceDisabled)
+        try await assertUncompressed(.disabled)
+        try await assertUncompressed(.enabledForCompressibleTypes)
+        try await assertCompressed(.enabled)
+
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .all, allowRequestOverrides: false))
+        try await assertUncompressed(.disabled(allowedTypes: .none, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .compressible, allowRequestOverrides: true))
+        try await assertUncompressed(.disabled(allowedTypes: .all, allowRequestOverrides: true))
+
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: false))
+        try await assertCompressed(.enabled(disallowedTypes: .none, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .incompressible, allowRequestOverrides: true))
+        try await assertCompressed(.enabled(disallowedTypes: .all, allowRequestOverrides: true))
+    }
+
     func testEnabledByResponse() async throws {
         app.get("resource") { request in
             var headers = HTTPHeaders()


### PR DESCRIPTION
**These changes are now available in [4.121.4](https://github.com/vapor/vapor/releases/tag/4.121.4)**


Fixes a bug in the response compression pipeline where the response would be compressed, even if response compression is disabled, if no content-type header was set for the response.
