### PR TITLE
fix(routing): enforce configurable body size

### DIFF
--- a/Sources/Vapor/Routing/RoutesBuilder+Method.swift
+++ b/Sources/Vapor/Routing/RoutesBuilder+Method.swift
@@ -2,6 +2,7 @@ import RoutingKit
 import HTTPTypes
 import NIOPosix
 import NIOCore
+import NIOConcurrencyHelpers
 
 /// Determines how an incoming HTTP request's body is collected.
 public enum HTTPBodyStreamStrategy: Sendable {
@@ -154,10 +155,20 @@ extension RoutesBuilder {
     ) -> Route {
         let responder = BasicResponder { request in
             if case .collect(let max) = body, request.body.data == nil {
-                _ = try await MultiThreadedEventLoopGroup.singleton.any().flatSubmit {
-                    request.body.collect(max: max?.value ?? request.application.routes.defaultMaxBodySize.value)
-                }.get()
-
+                let maxBodySize: Int = max?.value ?? request.application.routes.defaultMaxBodySize.value
+                if let newBody = request.newBodyStorage.withLockedValue({ $0 }) {
+                    do {
+                        let buffer = try await newBody.collect(upTo: maxBodySize)
+                        request.bodyStorage.withLockedValue { $0 = .collected(buffer) }
+                        request.newBodyStorage.withLockedValue { $0 = nil }
+                    } catch is NIOTooManyBytesError {
+                        throw Abort(.contentTooLarge)
+                    }
+                } else {
+                    _ = try await MultiThreadedEventLoopGroup.singleton.any().flatSubmit {
+                        request.body.collect(max: maxBodySize)
+                    }.get()
+                }
             }
             return try await closure(request).encodeResponse(for: request)
         }

--- a/Tests/VaporTests/RouteTests.swift
+++ b/Tests/VaporTests/RouteTests.swift
@@ -377,7 +377,7 @@ struct RouteTests {
         }
     }
 
-    @Test("Test Configurable Max Body Size", .disabled())
+    @Test("Test Configurable Max Body Size")
     func testConfigurableMaxBodySize() async throws {
         try await withApp { app in
             #expect(app.routes.defaultMaxBodySize == 16384)
@@ -399,20 +399,19 @@ struct RouteTests {
 
             var buffer = ByteBufferAllocator().buffer(capacity: 0)
             buffer.writeBytes(Array(repeating: 0, count: 500_000))
-            try await app.testing(method: .running).test(.post, "/default", body: buffer) { res in
-                #expect(res.status == .contentTooLarge)
-            }
 
-            try await app.testing(method: .running).test(.post, "/1kb", body: buffer) { res in
-                #expect(res.status == .contentTooLarge)
-            }
+            try await app.test(method: .running) { testApp in
+                let defaultResponse = try await testApp.sendRequest(.post, "/default", body: buffer)
+                #expect(defaultResponse.status == .contentTooLarge)
 
-            try await app.testing(method: .running).test(.post, "/1mb", body: buffer) { res in
-                #expect(res.status == .ok)
-            }
+                let oneKilobyteResponse = try await testApp.sendRequest(.post, "/1kb", body: buffer)
+                #expect(oneKilobyteResponse.status == .contentTooLarge)
 
-            try await app.testing(method: .running).test(.post, "/1gb", body: buffer) { res in
-                #expect(res.status == .ok)
+                let oneMegabyteResponse = try await testApp.sendRequest(.post, "/1mb", body: buffer)
+                #expect(oneMegabyteResponse.status == .ok)
+
+                let oneGigabyteResponse = try await testApp.sendRequest(.post, "/1gb", body: buffer)
+                #expect(oneGigabyteResponse.status == .ok)
             }
         }
     }


### PR DESCRIPTION
Updates route body collection so configurable max body size is enforced for requests handled by the Vapor 5 server path.

Previously, the route collection logic only collected `request.body`, but requests coming through `HTTPServerNew` store their body in `newBodyStorage`. That meant routes using `.collect` could skip body-size enforcement and continue to the handler, returning `200 OK` instead of `413 Content Too Large`.

This change collects from `newBodyStorage` when present, stores the collected buffer back into `bodyStorage` for the existing Vapor request APIs, and preserves the existing `request.body.collect(max:)` fallback for old body storage.

Also re-enables the configurable max body size test for running server requests.

Fixes #3388.