### PR TITLE
fix(auth): add basic auth challenge header

### DIFF
--- a/Sources/Vapor/Authentication/Authenticator.swift
+++ b/Sources/Vapor/Authentication/Authenticator.swift
@@ -1,4 +1,5 @@
 import NIOCore
+import HTTPTypes
 
 /// Capable of being authenticated.
 public protocol Authenticatable: Sendable { }
@@ -27,10 +28,38 @@ extension RequestAuthenticator {
 
 /// Helper for creating authentication middleware using the Basic authorization header.
 public protocol BasicAuthenticator: RequestAuthenticator {
+    /// Realm to advertise in the `WWW-Authenticate` challenge.
+    var realm: String { get }
+
     func authenticate(basic: BasicAuthorization, for request: Request) async throws
 }
 
 extension BasicAuthenticator {
+    public var realm: String {
+        "Vapor"
+    }
+
+    private var authenticateHeaderValue: HTTPFields.WWWAuthenticate {
+        .basic(realm: self.realm)
+    }
+
+    public func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
+        do {
+            try await self.authenticate(request: request)
+            let response = try await next.respond(to: request)
+            if response.status == .unauthorized, response.headers[.wwwAuthenticate] == nil {
+                response.headers.wwwAuthenticate = self.authenticateHeaderValue
+            }
+            return response
+        } catch let error as any AbortError where error.status == .unauthorized {
+            var headers = error.headers
+            if headers[.wwwAuthenticate] == nil {
+                headers.wwwAuthenticate = self.authenticateHeaderValue
+            }
+            throw Abort(.unauthorized, headers: headers, reason: error.reason)
+        }
+    }
+
     public func authenticate(request: Request) async throws {
         guard let basicAuthorization = request.headers.basicAuthorization else {
             return

--- a/Sources/Vapor/HTTP/Headers/HTTPFields+WWWAuthenticate.swift
+++ b/Sources/Vapor/HTTP/Headers/HTTPFields+WWWAuthenticate.swift
@@ -1,0 +1,46 @@
+import Foundation
+import HTTPTypes
+
+extension HTTPFields {
+    /// Represents the HTTP `WWW-Authenticate` header.
+    /// - See Also:
+    /// [WWW-Authenticate](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/WWW-Authenticate)
+    public struct WWWAuthenticate: ExpressibleByStringLiteral, Equatable, Sendable {
+        /// The serialized header value.
+        public let value: String
+
+        /// Creates a `WWW-Authenticate` header from a serialized header value.
+        public init(value: String) {
+            self.value = value
+        }
+
+        public init(stringLiteral value: String) {
+            self.init(value: value)
+        }
+
+        /// Creates a Basic authentication challenge.
+        public static func basic(realm: String) -> WWWAuthenticate {
+            .init(value: "Basic realm=\"\(realm.escapingHTTPQuotedString())\"")
+        }
+    }
+
+    /// Gets or sets the value of the `WWW-Authenticate` header, if present.
+    public var wwwAuthenticate: WWWAuthenticate? {
+        get { self[.wwwAuthenticate].map(WWWAuthenticate.init(value:)) }
+        set {
+            if let new = newValue {
+                self[.wwwAuthenticate] = new.value
+            } else {
+                self[.wwwAuthenticate] = nil
+            }
+        }
+    }
+}
+
+private extension String {
+    func escapingHTTPQuotedString() -> String {
+        self
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+    }
+}

--- a/Tests/VaporTests/AuthenticationTests.swift
+++ b/Tests/VaporTests/AuthenticationTests.swift
@@ -82,16 +82,48 @@ struct AuthenticationTests {
             let basic = "test:secret".data(using: .utf8)!.base64EncodedString()
             try await app.testing().test(.get, "/test") { res async in
                 #expect(res.status == .unauthorized)
+                #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Vapor""#)
             }
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "Basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "Vapor")
+                #expect(res.headers[.wwwAuthenticate] == nil)
             }
 
             try await app.testing().test(.get, "/test", headers: [.authorization: "basic \(basic)"]) { res async in
                 #expect(res.status == .ok)
                 #expect(res.body.string == "Vapor")
+            }
+        }
+    }
+
+    @Test("Test Basic Authenticator WWW Authenticate Header")
+    func basicAuthenticatorWWWAuthenticateHeader() async throws {
+        struct TestAuthenticator: BasicAuthenticator {
+            let realm = #"Private "Area""#
+
+            func authenticate(basic: BasicAuthorization, for request: Request) async throws { }
+        }
+
+        try await withApp { app in
+            app.routes.grouped(TestAuthenticator()).get("test") { _ in
+                Response(status: .unauthorized)
+            }
+            app.routes.grouped(TestAuthenticator()).get("existing") { _ -> Response in
+                let response = Response(status: .unauthorized)
+                response.headers[.wwwAuthenticate] = #"Basic realm="Existing""#
+                return response
+            }
+
+            try await app.testing().test(.get, "/test") { res async in
+                #expect(res.status == .unauthorized)
+                #expect(res.headers[.wwwAuthenticate] == "Basic realm=\"Private \\\"Area\\\"\"")
+            }
+
+            try await app.testing().test(.get, "/existing") { res async in
+                #expect(res.status == .unauthorized)
+                #expect(res.headers[.wwwAuthenticate] == #"Basic realm="Existing""#)
             }
         }
     }

--- a/Tests/VaporTests/HTTPHeaderTests.swift
+++ b/Tests/VaporTests/HTTPHeaderTests.swift
@@ -111,6 +111,20 @@ struct HTTPHeaderTests {
         #expect(serializer.serialize() == "foo; bar=\"baz\", qux=\"quuz\"")
     }
 
+    @Test("Test WWW-Authenticate Header")
+    func testWWWAuthenticate() throws {
+        var headers = HTTPFields()
+        headers.wwwAuthenticate = .basic(realm: "Private \"Area\"")
+        #expect(headers[.wwwAuthenticate] == "Basic realm=\"Private \\\"Area\\\"\"")
+        #expect(headers.wwwAuthenticate?.value == "Basic realm=\"Private \\\"Area\\\"\"")
+
+        headers.wwwAuthenticate = "Bearer realm=\"API\""
+        #expect(headers[.wwwAuthenticate] == #"Bearer realm="API""#)
+
+        headers.wwwAuthenticate = nil
+        #expect(headers[.wwwAuthenticate] == nil)
+    }
+
     @Test("Test Forwarded Header Parsing")
     func testForwarded() throws {
         var headers = HTTPFields()


### PR DESCRIPTION
Adds a typed `WWW-Authenticate` header helper and updates Basic authentication middleware to include a Basic challenge on unauthorized responses.

Previously, routes protected by `BasicAuthenticator` could return `401 Unauthorized` without a `WWW-Authenticate` header, which prevents clients such as browsers and `URLSession` from recognizing the response as an authentication challenge.

This change adds a default Basic realm of `Vapor`, while allowing authenticators to customize the realm by overriding `realm`:

```swift
struct AdminAuthenticator: BasicAuthenticator {
    var realm: String { "Admin" }

    func authenticate(basic: BasicAuthorization, for request: Request) async throws {
        // Authenticate credentials.
    }
}
```

Unauthorized Basic auth responses now include:

```http
WWW-Authenticate: Basic realm="Vapor"
```

If a response or thrown abort already includes `WWW-Authenticate`, Vapor preserves the existing header.

Fixes #2337.
