### PR TITLE
Add @Controller path prefix support

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -271,6 +271,8 @@ public func routes(_ app: Application) async throws {
 
     #if MacroRouting
     try await app.register(collection: UserController())
+    try await app.register(collection: PrefixedArticlesController())
+    try await app.register(collection: TenantsController())
 
     #GET(on: app, "macros", "types", Int.self) { (req: Request, id: Int) async throws -> String in
         return "macro route with id: \(id)"
@@ -411,3 +413,41 @@ struct UserAuthMiddleware: Middleware {
         return try await next.respond(to: request)
      }
 }
+
+#if MacroRouting
+// Demonstrates @Controller with a static string path prefix. Every route here
+// sits under /api/articles without repeating the prefix on each @GET/@POST.
+@Controller("api", "articles")
+struct PrefixedArticlesController {
+    @GET()
+    func list(req: Request) async throws -> String {
+        return "articles"
+    }
+
+    @GET(String.self)
+    func read(req: Request, slug: String) async throws -> String {
+        return "article: \(slug)"
+    }
+
+    @POST()
+    func create(req: Request) async throws -> String {
+        return "created"
+    }
+}
+
+// Demonstrates @Controller with a dynamic path-prefix parameter. The tenantID
+// is extracted once and made available to every handler in the controller,
+// including handlers that also declare their own dynamic path params.
+@Controller("tenants", Int.self)
+struct TenantsController {
+    @GET("posts")
+    func listPosts(req: Request, tenantID: Int) async throws -> String {
+        return "posts for tenant \(tenantID)"
+    }
+
+    @GET("posts", String.self)
+    func getPost(req: Request, tenantID: Int, slug: String) async throws -> String {
+        return "post \(slug) for tenant \(tenantID)"
+    }
+}
+#endif

--- a/Sources/VaporMacros/MacroInterface.swift
+++ b/Sources/VaporMacros/MacroInterface.swift
@@ -3,7 +3,7 @@ import HTTPTypes
 import Vapor
 
 @attached(extension, conformances: RouteCollection, names: named(boot(routes:)))
-public macro Controller() = #externalMacro(
+public macro Controller(_ pathComponents: Any...) = #externalMacro(
     module: "VaporMacrosPlugin",
     type: "ControllerMacro",
 )

--- a/Sources/VaporMacrosPlugin/ControllerMacro.swift
+++ b/Sources/VaporMacrosPlugin/ControllerMacro.swift
@@ -13,6 +13,13 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
     }
 
     public static func expansion(of node: AttributeSyntax, attachedTo declaration: some DeclGroupSyntax, providingExtensionsOf type: some TypeSyntaxProtocol, conformingTo protocols: [TypeSyntax], in context: some MacroExpansionContext) throws -> [ExtensionDeclSyntax] {
+        // Parse the @Controller(...) path prefix. Supports string literals and `Type.self` for dynamic params.
+        let controllerArgs: LabeledExprListSyntax? = switch node.arguments {
+        case .argumentList(let args): args
+        default: nil
+        }
+        let prefix = HTTPMethodMacroUtilities.parsePathComponents(from: controllerArgs, startingIndex: 0)
+
         // Find all functions with route macros
         let functions = try declaration.memberBlock.members.compactMap { member -> (FunctionDeclSyntax, String, [String], [String])? in
             guard let funcDecl = member.decl.as(FunctionDeclSyntax.self) else {
@@ -45,29 +52,12 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                     customHTTPMethod = false
                 }
 
-                // Parse path components
-                var pathComponents: [String] = []
-                var currentDynamicPathParameterIndex = 0
-                if let arguments {
-                    for (index, arg) in arguments.enumerated() {
-                        // If we're a custom HTTP method, discard the first one
-                        if customHTTPMethod && index == 0 {
-                            continue
-                        }
-                        let exprStr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                        // Check if it's a type (contains .self)
-                        if exprStr.hasSuffix(".self") {
-                            let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                            pathComponents.append(":\(typeName.lowercased())\(currentDynamicPathParameterIndex)")
-                            currentDynamicPathParameterIndex += 1
-                        } else {
-                            // It's a string literal
-                            let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                            pathComponents.append(cleaned)
-                        }
-                    }
-                }
+                // Parse the route-local path components, indexed continuously after the prefix.
+                let route = HTTPMethodMacroUtilities.parsePathComponents(
+                    from: arguments,
+                    startingIndex: prefix.nextIndex,
+                    skipFirstUnlabeled: customHTTPMethod
+                )
 
                 // Check for @AuthMiddleware
                 let middlewareExprs: [String] = {
@@ -77,7 +67,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                     return authInfo.middlewares
                 }()
 
-                return (funcDecl, httpMethod, pathComponents, middlewareExprs)
+                return (funcDecl, httpMethod, route.routeRegistrationSegments, middlewareExprs)
             }
 
             return nil
@@ -85,6 +75,21 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
 
         // Generate the RouteCollection boot function
         var registrationBody = ""
+
+        // Choose the builder expression each route hangs off of.
+        // When @Controller has a non-empty path prefix, introduce `let group = routes.grouped(...)`
+        // so nested groups (for middleware, later) can chain cleanly.
+        let baseBuilder: String
+        if prefix.routeRegistrationSegments.isEmpty {
+            baseBuilder = "routes"
+        } else {
+            let prefixLiteral = prefix.routeRegistrationSegments.joined(separator: "\", \"")
+            registrationBody += """
+            let group = routes.grouped("\(prefixLiteral)")
+
+            """
+            baseBuilder = "group"
+        }
 
         for (functionDeclaration, method, pathComponents, middlewares) in functions {
             let path = pathComponents.joined(separator: "\", \"")
@@ -100,7 +105,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
 
             if middlewares.isEmpty {
                 registrationBody += """
-                routes.\(methodLower)\(pathRegistration) { req async throws -> Response in
+                \(baseBuilder).\(methodLower)\(pathRegistration) { req async throws -> Response in
                     try await self.\(functionName)(req: req)
                 }
 
@@ -108,7 +113,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
             } else {
                 let middlewareList = middlewares.joined(separator: ", ")
                 registrationBody += """
-                routes.grouped(\(middlewareList)).\(methodLower)\(pathRegistration) { req async throws -> Response in
+                \(baseBuilder).grouped(\(middlewareList)).\(methodLower)\(pathRegistration) { req async throws -> Response in
                     try await self.\(functionName)(req: req)
                 }
 

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
@@ -5,6 +5,92 @@ import Foundation
 import HTTPTypes
 
 enum HTTPMethodMacroUtilities {
+    /// Rendered path segments + dynamic parameter types parsed from a macro attribute's arguments.
+    struct ParsedPathComponents {
+        /// Each element is either a literal path segment ("users") or a dynamic placeholder (":int0").
+        var routeRegistrationSegments: [String]
+        /// Names of dynamic parameter types in declaration order (e.g. ["Int", "String"]).
+        var parameterTypes: [String]
+        /// Next index available for continuing the naming scheme across multiple argument lists.
+        var nextIndex: Int
+    }
+
+    /// Parse a macro attribute's argument list into path registration segments and dynamic parameter types.
+    /// - Parameters:
+    ///   - arguments: The attribute's labeled expression list (e.g. `@GET`'s args).
+    ///   - startingIndex: Index to use for the first dynamic param encountered; allows continuous indexing
+    ///                    when combining a controller prefix with per-route params.
+    ///   - skipFirstUnlabeled: Skip the first non-`on:` argument (used for `@HTTP(.patch, ...)` where the
+    ///                         first argument is the HTTP method, not a path component).
+    static func parsePathComponents(
+        from arguments: LabeledExprListSyntax?,
+        startingIndex: Int = 0,
+        skipFirstUnlabeled: Bool = false
+    ) -> ParsedPathComponents {
+        var segments: [String] = []
+        var types: [String] = []
+        var currentIndex = startingIndex
+        var skippedFirstUnlabeled = false
+
+        guard let arguments else {
+            return ParsedPathComponents(routeRegistrationSegments: [], parameterTypes: [], nextIndex: startingIndex)
+        }
+
+        for argument in arguments {
+            if argument.label?.text == "on" {
+                continue
+            }
+            if skipFirstUnlabeled && !skippedFirstUnlabeled {
+                skippedFirstUnlabeled = true
+                continue
+            }
+
+            let exprStr = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            if exprStr.hasSuffix(".self") {
+                let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
+                segments.append(":\(typeName.lowercased())\(currentIndex)")
+                types.append(typeName)
+                currentIndex += 1
+            } else {
+                let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                segments.append(cleaned)
+            }
+        }
+
+        return ParsedPathComponents(routeRegistrationSegments: segments, parameterTypes: types, nextIndex: currentIndex)
+    }
+
+    /// If the macro is expanded inside a `@Controller`-annotated type declaration, return its attribute arguments.
+    /// Returns nil when not inside a controller or when the enclosing type is not `@Controller`-annotated.
+    static func enclosingControllerArguments(in context: some MacroExpansionContext) -> LabeledExprListSyntax? {
+        for lexical in context.lexicalContext {
+            let attributes: AttributeListSyntax? = {
+                if let structDecl = lexical.as(StructDeclSyntax.self) { return structDecl.attributes }
+                if let classDecl = lexical.as(ClassDeclSyntax.self) { return classDecl.attributes }
+                if let actorDecl = lexical.as(ActorDeclSyntax.self) { return actorDecl.attributes }
+                return nil
+            }()
+
+            guard let attributes else { continue }
+
+            for attribute in attributes {
+                guard case let .attribute(attr) = attribute,
+                      let identifier = attr.attributeName.as(IdentifierTypeSyntax.self),
+                      identifier.name.text == "Controller" else {
+                    continue
+                }
+                switch attr.arguments {
+                case .argumentList(let args):
+                    return args
+                default:
+                    // @Controller with no arguments.
+                    return LabeledExprListSyntax([])
+                }
+            }
+        }
+        return nil
+    }
+
     public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -77,34 +163,32 @@ enum HTTPMethodMacroUtilities {
             }
         }
 
-        // Parse path components and parameter types
-        var parameterTypes: [String] = []
+        // Detect enclosing @Controller so we can account for prefix-declared dynamic params.
+        // Prefix params come first in the handler's parameter list by convention.
+        let enclosingPrefix = enclosingControllerArguments(in: context).map {
+            parsePathComponents(from: $0, startingIndex: 0, skipFirstUnlabeled: false)
+        } ?? ParsedPathComponents(routeRegistrationSegments: [], parameterTypes: [], nextIndex: 0)
+
+        // Parse this macro's own path components, indexed continuously after the prefix's dynamic params.
+        let routeComponents = parsePathComponents(
+            from: arguments,
+            startingIndex: enclosingPrefix.nextIndex,
+            skipFirstUnlabeled: customHTTPMethod
+        )
+
+        let allParameterTypes = enclosingPrefix.parameterTypes + routeComponents.parameterTypes
+
+        // Detect `on:` label for standalone/freestanding usage (not used when inside a controller).
         var routeRegistrationVariable: String? = nil
-
-        var skippedHTTPMethod = false
         if let arguments {
-            for (_, argument) in arguments.enumerated() {
-                if argument.label?.text == "on" {
-                    routeRegistrationVariable = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-                    continue
-                }
-                // Skip the first non-on: argument for custom HTTP methods (that's the HTTP method itself)
-                if customHTTPMethod && !skippedHTTPMethod {
-                    skippedHTTPMethod = true
-                    continue
-                }
-
-                let exprStr = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if exprStr.hasSuffix(".self") {
-                    let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                    parameterTypes.append(typeName)
-                }
+            for argument in arguments where argument.label?.text == "on" {
+                routeRegistrationVariable = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                break
             }
         }
 
-        guard pathParams.count == parameterTypes.count else {
-            throw MacroError.invalidNumberOfParameters(macroName, parameterTypes.count, pathParams.count)
+        guard pathParams.count == allParameterTypes.count else {
+            throw MacroError.invalidNumberOfParameters(macroName, allParameterTypes.count, pathParams.count)
         }
 
         let functionName = funcDecl.name.text
@@ -113,6 +197,7 @@ enum HTTPMethodMacroUtilities {
         var parameterExtraction = ""
         var callParameters = "req: req"
         var pathParamIndex = 0
+        let dynamicIndexBase = 0  // index used in :typeN naming starts at 0 regardless of prefix vs route
 
         for (param, isAuth, isOptionalAuth) in allParamsWithAuth {
             let functionParameterName = param.firstName.text
@@ -131,10 +216,11 @@ enum HTTPMethodMacroUtilities {
                 }
                 callParameters += ", \(functionParameterName): \(varName)"
             } else {
-                let paramType = parameterTypes[pathParamIndex]
-                let parameterName = "\(paramType.lowercased())\(pathParamIndex)"
+                let paramType = allParameterTypes[pathParamIndex]
+                let globalIndex = dynamicIndexBase + pathParamIndex
+                let parameterName = "\(paramType.lowercased())\(globalIndex)"
                 parameterExtraction += """
-                let \(parameterName) = try req.parameters.require("\(paramType.lowercased())\(pathParamIndex)", as: \(paramType).self)
+                let \(parameterName) = try req.parameters.require("\(paramType.lowercased())\(globalIndex)", as: \(paramType).self)
 
                 """
                 callParameters += ", \(functionParameterName): \(parameterName)"
@@ -179,36 +265,7 @@ enum HTTPMethodMacroUtilities {
         }
 
         if let routeRegistrationVariable {
-            var currentDynamicPathParameterIndex = 0
-            var pathComponents: [String] = []
-            if let arguments {
-                var skippedHTTPMethodInPath = false
-                for (_, arg) in arguments.enumerated() {
-                    // Skip the `on:` argument
-                    if arg.label?.text == "on" {
-                        continue
-                    }
-                    // Skip the first non-on: argument for custom HTTP methods
-                    if customHTTPMethod && !skippedHTTPMethodInPath {
-                        skippedHTTPMethodInPath = true
-                        continue
-                    }
-                    let exprStr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                    // Check if it's a type (contains .self)
-                    if exprStr.hasSuffix(".self") {
-                        let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                        pathComponents.append(":\(typeName.lowercased())\(currentDynamicPathParameterIndex)")
-                        currentDynamicPathParameterIndex += 1
-                    } else {
-                        // It's a string literal
-                        let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                        pathComponents.append(cleaned)
-                    }
-                }
-            }
-
-            let path = pathComponents.joined(separator: "\", \"")
+            let path = routeComponents.routeRegistrationSegments.joined(separator: "\", \"")
             let pathRegistration = if path == "" {
                 ""
             } else {

--- a/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
@@ -79,6 +79,77 @@ struct ControllerMacroIntegrationTests {
             }
         }
     }
+
+    // MARK: - Path Prefix (#3397)
+
+    @Test("Controller with string path prefix routes correctly")
+    func controllerStringPathPrefix() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedController())
+
+            try await app.testing().test(.get, "/api/prefixed/items") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "items")
+            }
+
+            try await app.testing().test(.post, "/api/prefixed/items") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "created")
+            }
+        }
+    }
+
+    @Test("Controller with dynamic path prefix extracts prefix param")
+    func controllerDynamicPathPrefix() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedTenantController())
+
+            try await app.testing().test(.get, "/tenants/42/posts") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "posts for tenant 42")
+            }
+        }
+    }
+
+    @Test("Controller with dynamic prefix + dynamic route param extracts both")
+    func controllerDynamicPrefixAndRouteParam() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedTenantController())
+
+            try await app.testing().test(.get, "/tenants/7/posts/welcome") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "post welcome for tenant 7")
+            }
+        }
+    }
+}
+
+// MARK: - Prefix test controllers
+
+@Controller("api", "prefixed")
+struct PrefixedController {
+    @GET("items")
+    func list(req: Request) async throws -> String {
+        return "items"
+    }
+
+    @POST("items")
+    func create(req: Request) async throws -> String {
+        return "created"
+    }
+}
+
+@Controller("tenants", Int.self)
+struct PrefixedTenantController {
+    @GET("posts")
+    func listPosts(req: Request, tenantID: Int) async throws -> String {
+        return "posts for tenant \(tenantID)"
+    }
+
+    @GET("posts", String.self)
+    func getPost(req: Request, tenantID: Int, slug: String) async throws -> String {
+        return "post \(slug) for tenant \(tenantID)"
+    }
 }
 
 // MARK: - Test Controller

--- a/Tests/VaporMacroTests/ControllerMacroTests.swift
+++ b/Tests/VaporMacroTests/ControllerMacroTests.swift
@@ -289,19 +289,237 @@ struct ControllerMacroTests {
                 func getUsers(req: Request) async throws -> String {
                     return "Users"
                 }
-            
+
                 @Sendable func _route_getUsers(req: Request) async throws -> Response {
                     let result: some ResponseEncodable = try await getUsers(req: req)
                     return try await result.encodeResponse(for: req)
                 }
             }
-            
+
             extension UserController: RouteCollection {
                 func boot(routes: any RoutesBuilder) throws {
                 routes.get { req async throws -> Response in
                     try await self._route_getUsers(req: req)
                 }
-            
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    // MARK: - Path Prefix (#3397)
+
+    @Test("Test Controller with string path prefix")
+    func testControllerWithStringPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("api", "users")
+            struct UserController {
+                @GET()
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @POST("invite")
+                func invite(req: Request) async throws -> String {
+                    return "Invited"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+                func invite(req: Request) async throws -> String {
+                    return "Invited"
+                }
+
+                @Sendable func _route_invite(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await invite(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("api", "users")
+                group.get { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+                group.post("invite") { req async throws -> Response in
+                    try await self._route_invite(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with dynamic path prefix")
+    func testControllerWithDynamicPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("users", Int.self)
+            struct UserController {
+                @GET("posts")
+                func listPosts(req: Request, userID: Int) async throws -> String {
+                    return "posts for user \\(userID)"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func listPosts(req: Request, userID: Int) async throws -> String {
+                    return "posts for user \\(userID)"
+                }
+
+                @Sendable func _route_listPosts(req: Request) async throws -> Response {
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let result: some ResponseEncodable = try await listPosts(req: req, userID: int0)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("users", ":int0")
+                group.get("posts") { req async throws -> Response in
+                    try await self._route_listPosts(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with dynamic prefix and dynamic route param")
+    func testControllerWithDynamicPrefixAndRouteParam() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("users", Int.self)
+            struct UserController {
+                @GET("posts", String.self)
+                func getPost(req: Request, userID: Int, slug: String) async throws -> String {
+                    return "post \\(slug) for user \\(userID)"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func getPost(req: Request, userID: Int, slug: String) async throws -> String {
+                    return "post \\(slug) for user \\(userID)"
+                }
+
+                @Sendable func _route_getPost(req: Request) async throws -> Response {
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let string1 = try req.parameters.require("string1", as: String.self)
+                    let result: some ResponseEncodable = try await getPost(req: req, userID: int0, slug: string1)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("users", ":int0")
+                group.get("posts", ":string1") { req async throws -> Response in
+                    try await self._route_getPost(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with empty path prefix is a no-op")
+    func testControllerEmptyPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller()
+            struct UserController {
+                @GET("api", "users")
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                routes.get("api", "users") { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller path prefix composes with AuthMiddleware")
+    func testControllerPathPrefixWithAuthMiddleware() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("api", "users")
+            struct UserController {
+                @POST("promote", Int.self)
+                @AuthMiddleware(User.self, UserAuthMiddleware())
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+
+                @Sendable func _route_promote(req: Request) async throws -> Response {
+                    let user = try req.auth.require(User.self)
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let result: some ResponseEncodable = try await promote(req: req, user: user, id: int0)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("api", "users")
+                group.grouped(UserAuthMiddleware()).post("promote", ":int0") { req async throws -> Response in
+                    try await self._route_promote(req: req)
+                }
+
                 }
             }
             """,


### PR DESCRIPTION
Resolves #3397.

## Summary

`@Controller` now accepts variadic path components so an entire controller can sit under a shared path prefix, including dynamic parameters:

```swift
@Controller("tenants", Int.self)
struct TenantsController {
    @GET("posts")
    func listPosts(req: Request, tenantID: Int) async throws -> [Post] { ... }

    @GET("posts", String.self)
    func getPost(req: Request, tenantID: Int, slug: String) async throws -> Post { ... }
}
```

Generates a single `let group = routes.grouped("tenants", ":int0")` when a prefix is supplied, and peer macros pick up the prefix via `context.lexicalContext` so `_route_*` wrappers extract prefix-declared parameters in addition to the function's own path params. Path parameter naming uses a continuous index across prefix + route to avoid collisions when both sides declare dynamic params of the same type.

Bare `@Controller` and `@Controller()` continue to expand exactly as before — the existing `UserController` demo keeps its original shape so the non-prefix code path stays exercised. New demo controllers (`PrefixedArticlesController`, `TenantsController`) show off the new feature without disturbing the baseline.

## Implementation

- Hoist path-component parsing into `HTTPMethodMacroUtilities.parsePathComponents` so `ControllerMacro` and the HTTP method peer macros share one implementation.
- `HTTPMethodMacroUtilities.enclosingControllerArguments(in:)` walks `context.lexicalContext` for an enclosing `@Controller` on `StructDeclSyntax` / `ClassDeclSyntax` / `ActorDeclSyntax`.
- Single dynamic-index counter spans prefix + route so `@Controller(\"tenants\", Int.self)` + `@GET(\"posts\", String.self)` yields `:int0` + `:string1` (no collisions).

## Test plan

- [x] Unit tests for string prefix, dynamic prefix, combined prefix + route params, empty `@Controller()` regression, and composition with `@AuthMiddleware`.
- [x] Integration tests hit live routes through the generated `boot` code and assert both status and response body.
- [x] Existing 38 macro unit tests + all integration tests continue to pass (62 total).
- [x] `swift run Development` serves the new controllers end-to-end.

Stacked PR #3396 adds `@Middleware` on top of this; reviewing this one first keeps each diff focused.