### PR TITLE
Add @Middleware macro for controllers and routes

### DIFF
--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -271,6 +271,8 @@ public func routes(_ app: Application) async throws {
 
     #if MacroRouting
     try await app.register(collection: UserController())
+    try await app.register(collection: PrefixedArticlesController())
+    try await app.register(collection: TenantsController())
 
     #GET(on: app, "macros", "types", Int.self) { (req: Request, id: Int) async throws -> String in
         return "macro route with id: \(id)"
@@ -411,3 +413,41 @@ struct UserAuthMiddleware: Middleware {
         return try await next.respond(to: request)
      }
 }
+
+#if MacroRouting
+// Demonstrates @Controller with a static string path prefix. Every route here
+// sits under /api/articles without repeating the prefix on each @GET/@POST.
+@Controller("api", "articles")
+struct PrefixedArticlesController {
+    @GET()
+    func list(req: Request) async throws -> String {
+        return "articles"
+    }
+
+    @GET(String.self)
+    func read(req: Request, slug: String) async throws -> String {
+        return "article: \(slug)"
+    }
+
+    @POST()
+    func create(req: Request) async throws -> String {
+        return "created"
+    }
+}
+
+// Demonstrates @Controller with a dynamic path-prefix parameter. The tenantID
+// is extracted once and made available to every handler in the controller,
+// including handlers that also declare their own dynamic path params.
+@Controller("tenants", Int.self)
+struct TenantsController {
+    @GET("posts")
+    func listPosts(req: Request, tenantID: Int) async throws -> String {
+        return "posts for tenant \(tenantID)"
+    }
+
+    @GET("posts", String.self)
+    func getPost(req: Request, tenantID: Int, slug: String) async throws -> String {
+        return "post \(slug) for tenant \(tenantID)"
+    }
+}
+#endif

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -273,6 +273,8 @@ public func routes(_ app: Application) async throws {
     try await app.register(collection: UserController())
     try await app.register(collection: PrefixedArticlesController())
     try await app.register(collection: TenantsController())
+    try await app.register(collection: MiddlewareDemoController())
+    try await app.register(collection: MixedMiddlewareController())
 
     #GET(on: app, "macros", "types", Int.self) { (req: Request, id: Int) async throws -> String in
         return "macro route with id: \(id)"
@@ -448,6 +450,37 @@ struct TenantsController {
     @GET("posts", String.self)
     func getPost(req: Request, tenantID: Int, slug: String) async throws -> String {
         return "post \(slug) for tenant \(tenantID)"
+    }
+}
+
+// Demonstrates @Middleware attached at the controller level (applies to every
+// route) and at the route level (applies only to that route). Visit the routes
+// and inspect logs from TestMiddleware to see the ordering.
+@Controller("api", "demo")
+@Middleware(TestMiddleware(number: 1))
+struct MiddlewareDemoController {
+    @GET("open")
+    func open(req: Request) async throws -> String {
+        return "open"
+    }
+
+    @GET("throttled")
+    @Middleware(TestMiddleware(number: 2))
+    func throttled(req: Request) async throws -> String {
+        return "throttled"
+    }
+}
+
+// Demonstrates @Middleware composing with @AuthMiddleware. The per-route
+// @Middleware runs before @AuthMiddleware so rate-limiters and logging see
+// unauthenticated traffic too.
+@Controller("api", "secure")
+struct MixedMiddlewareController {
+    @POST("promote", Int.self)
+    @Middleware(TestMiddleware(number: 3))
+    @AuthMiddleware(User.self, UserAuthMiddleware())
+    func promote(req: Request, authenticatedUser: User, id: Int) async throws -> User {
+        return authenticatedUser
     }
 }
 #endif

--- a/Sources/VaporMacros/MacroInterface.swift
+++ b/Sources/VaporMacros/MacroInterface.swift
@@ -90,4 +90,16 @@ public macro AuthMiddleware<T: Authenticatable>(_ authenticationType: T.Type, _ 
     module: "VaporMacrosPlugin",
     type: "AuthMiddlewareMacro"
 )
+
+/// Attach middleware to a `@Controller`-annotated type (applies to all routes) or a single route function
+/// (applies only to that route). Arguments are spliced into a `routes.grouped(...)` call verbatim, so any
+/// expression valid in Swift (including factory calls like `User.authenticator()`) is accepted.
+///
+/// Execution order: when combined with `@AuthMiddleware` on the same function, route-level `@Middleware`
+/// runs first so rate-limiters and logging see requests regardless of authentication state.
+@attached(peer)
+public macro Middleware(_ middlewares: Any...) = #externalMacro(
+    module: "VaporMacrosPlugin",
+    type: "MiddlewareMacro"
+)
 #endif

--- a/Sources/VaporMacros/MacroInterface.swift
+++ b/Sources/VaporMacros/MacroInterface.swift
@@ -3,7 +3,7 @@ import HTTPTypes
 import Vapor
 
 @attached(extension, conformances: RouteCollection, names: named(boot(routes:)))
-public macro Controller() = #externalMacro(
+public macro Controller(_ pathComponents: Any...) = #externalMacro(
     module: "VaporMacrosPlugin",
     type: "ControllerMacro",
 )

--- a/Sources/VaporMacrosPlugin/ControllerMacro.swift
+++ b/Sources/VaporMacrosPlugin/ControllerMacro.swift
@@ -13,6 +13,13 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
     }
 
     public static func expansion(of node: AttributeSyntax, attachedTo declaration: some DeclGroupSyntax, providingExtensionsOf type: some TypeSyntaxProtocol, conformingTo protocols: [TypeSyntax], in context: some MacroExpansionContext) throws -> [ExtensionDeclSyntax] {
+        // Parse the @Controller(...) path prefix. Supports string literals and `Type.self` for dynamic params.
+        let controllerArgs: LabeledExprListSyntax? = switch node.arguments {
+        case .argumentList(let args): args
+        default: nil
+        }
+        let prefix = HTTPMethodMacroUtilities.parsePathComponents(from: controllerArgs, startingIndex: 0)
+
         // Find all functions with route macros
         let functions = try declaration.memberBlock.members.compactMap { member -> (FunctionDeclSyntax, String, [String], [String])? in
             guard let funcDecl = member.decl.as(FunctionDeclSyntax.self) else {
@@ -45,29 +52,12 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                     customHTTPMethod = false
                 }
 
-                // Parse path components
-                var pathComponents: [String] = []
-                var currentDynamicPathParameterIndex = 0
-                if let arguments {
-                    for (index, arg) in arguments.enumerated() {
-                        // If we're a custom HTTP method, discard the first one
-                        if customHTTPMethod && index == 0 {
-                            continue
-                        }
-                        let exprStr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                        // Check if it's a type (contains .self)
-                        if exprStr.hasSuffix(".self") {
-                            let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                            pathComponents.append(":\(typeName.lowercased())\(currentDynamicPathParameterIndex)")
-                            currentDynamicPathParameterIndex += 1
-                        } else {
-                            // It's a string literal
-                            let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                            pathComponents.append(cleaned)
-                        }
-                    }
-                }
+                // Parse the route-local path components, indexed continuously after the prefix.
+                let route = HTTPMethodMacroUtilities.parsePathComponents(
+                    from: arguments,
+                    startingIndex: prefix.nextIndex,
+                    skipFirstUnlabeled: customHTTPMethod
+                )
 
                 // Check for @AuthMiddleware
                 let middlewareExprs: [String] = {
@@ -77,7 +67,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                     return authInfo.middlewares
                 }()
 
-                return (funcDecl, httpMethod, pathComponents, middlewareExprs)
+                return (funcDecl, httpMethod, route.routeRegistrationSegments, middlewareExprs)
             }
 
             return nil
@@ -85,6 +75,21 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
 
         // Generate the RouteCollection boot function
         var registrationBody = ""
+
+        // Choose the builder expression each route hangs off of.
+        // When @Controller has a non-empty path prefix, introduce `let group = routes.grouped(...)`
+        // so nested groups (for middleware, later) can chain cleanly.
+        let baseBuilder: String
+        if prefix.routeRegistrationSegments.isEmpty {
+            baseBuilder = "routes"
+        } else {
+            let prefixLiteral = prefix.routeRegistrationSegments.joined(separator: "\", \"")
+            registrationBody += """
+            let group = routes.grouped("\(prefixLiteral)")
+
+            """
+            baseBuilder = "group"
+        }
 
         for (functionDeclaration, method, pathComponents, middlewares) in functions {
             let path = pathComponents.joined(separator: "\", \"")
@@ -100,7 +105,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
 
             if middlewares.isEmpty {
                 registrationBody += """
-                routes.\(methodLower)\(pathRegistration) { req async throws -> Response in
+                \(baseBuilder).\(methodLower)\(pathRegistration) { req async throws -> Response in
                     try await self.\(functionName)(req: req)
                 }
 
@@ -108,7 +113,7 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
             } else {
                 let middlewareList = middlewares.joined(separator: ", ")
                 registrationBody += """
-                routes.grouped(\(middlewareList)).\(methodLower)\(pathRegistration) { req async throws -> Response in
+                \(baseBuilder).grouped(\(middlewareList)).\(methodLower)\(pathRegistration) { req async throws -> Response in
                     try await self.\(functionName)(req: req)
                 }
 

--- a/Sources/VaporMacrosPlugin/ControllerMacro.swift
+++ b/Sources/VaporMacrosPlugin/ControllerMacro.swift
@@ -20,8 +20,12 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
         }
         let prefix = HTTPMethodMacroUtilities.parsePathComponents(from: controllerArgs, startingIndex: 0)
 
+        // Type-level @Middleware applied to all routes. Goes outside the path group so middleware
+        // sees every request reaching the controller, not just path-matched ones.
+        let typeMiddlewares = HTTPMethodMacroUtilities.parseMiddleware(from: declaration)
+
         // Find all functions with route macros
-        let functions = try declaration.memberBlock.members.compactMap { member -> (FunctionDeclSyntax, String, [String], [String])? in
+        let functions = try declaration.memberBlock.members.compactMap { member -> (FunctionDeclSyntax, String, [String], [String], [String])? in
             guard let funcDecl = member.decl.as(FunctionDeclSyntax.self) else {
                 return nil
             }
@@ -59,15 +63,12 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                     skipFirstUnlabeled: customHTTPMethod
                 )
 
-                // Check for @AuthMiddleware
-                let middlewareExprs: [String] = {
-                    guard let authInfo = HTTPMethodMacroUtilities.parseAuthMiddleware(from: funcDecl) else {
-                        return []
-                    }
-                    return authInfo.middlewares
-                }()
+                // Per-route @Middleware runs before @AuthMiddleware so rate-limiters and logging
+                // see unauthenticated traffic too.
+                let routeMiddlewares = HTTPMethodMacroUtilities.parseMiddleware(from: funcDecl)
+                let authMiddlewares = HTTPMethodMacroUtilities.parseAuthMiddleware(from: funcDecl)?.middlewares ?? []
 
-                return (funcDecl, httpMethod, route.routeRegistrationSegments, middlewareExprs)
+                return (funcDecl, httpMethod, route.routeRegistrationSegments, routeMiddlewares, authMiddlewares)
             }
 
             return nil
@@ -76,22 +77,27 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
         // Generate the RouteCollection boot function
         var registrationBody = ""
 
-        // Choose the builder expression each route hangs off of.
-        // When @Controller has a non-empty path prefix, introduce `let group = routes.grouped(...)`
-        // so nested groups (for middleware, later) can chain cleanly.
-        let baseBuilder: String
-        if prefix.routeRegistrationSegments.isEmpty {
-            baseBuilder = "routes"
-        } else {
+        // Build the base route builder: type-level middleware (if any) wraps `routes`, then the path prefix.
+        // Order: routes -> grouped(typeMW...) -> grouped(prefix...). Middleware runs before path matching.
+        var baseBuilder = "routes"
+        if !typeMiddlewares.isEmpty {
+            let typeMWList = typeMiddlewares.joined(separator: ", ")
+            registrationBody += """
+            let base = routes.grouped(\(typeMWList))
+
+            """
+            baseBuilder = "base"
+        }
+        if !prefix.routeRegistrationSegments.isEmpty {
             let prefixLiteral = prefix.routeRegistrationSegments.joined(separator: "\", \"")
             registrationBody += """
-            let group = routes.grouped("\(prefixLiteral)")
+            let group = \(baseBuilder).grouped("\(prefixLiteral)")
 
             """
             baseBuilder = "group"
         }
 
-        for (functionDeclaration, method, pathComponents, middlewares) in functions {
+        for (functionDeclaration, method, pathComponents, routeMiddlewares, authMiddlewares) in functions {
             let path = pathComponents.joined(separator: "\", \"")
             let methodLower = method.lowercased()
 
@@ -103,22 +109,21 @@ public struct ControllerMacro: ExtensionMacro, MemberAttributeMacro, MemberMacro
                 "(\"\(path)\")"
             }
 
-            if middlewares.isEmpty {
-                registrationBody += """
-                \(baseBuilder).\(methodLower)\(pathRegistration) { req async throws -> Response in
-                    try await self.\(functionName)(req: req)
-                }
-
-                """
-            } else {
-                let middlewareList = middlewares.joined(separator: ", ")
-                registrationBody += """
-                \(baseBuilder).grouped(\(middlewareList)).\(methodLower)\(pathRegistration) { req async throws -> Response in
-                    try await self.\(functionName)(req: req)
-                }
-
-                """
+            // Per-route middleware chain: route-level @Middleware first, then @AuthMiddleware middlewares.
+            var callChain = baseBuilder
+            if !routeMiddlewares.isEmpty {
+                callChain += ".grouped(\(routeMiddlewares.joined(separator: ", ")))"
             }
+            if !authMiddlewares.isEmpty {
+                callChain += ".grouped(\(authMiddlewares.joined(separator: ", ")))"
+            }
+
+            registrationBody += """
+            \(callChain).\(methodLower)\(pathRegistration) { req async throws -> Response in
+                try await self.\(functionName)(req: req)
+            }
+
+            """
         }
 
         let registrationFunc: DeclSyntax = """

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
@@ -5,6 +5,92 @@ import Foundation
 import HTTPTypes
 
 enum HTTPMethodMacroUtilities {
+    /// Rendered path segments + dynamic parameter types parsed from a macro attribute's arguments.
+    struct ParsedPathComponents {
+        /// Each element is either a literal path segment ("users") or a dynamic placeholder (":int0").
+        var routeRegistrationSegments: [String]
+        /// Names of dynamic parameter types in declaration order (e.g. ["Int", "String"]).
+        var parameterTypes: [String]
+        /// Next index available for continuing the naming scheme across multiple argument lists.
+        var nextIndex: Int
+    }
+
+    /// Parse a macro attribute's argument list into path registration segments and dynamic parameter types.
+    /// - Parameters:
+    ///   - arguments: The attribute's labeled expression list (e.g. `@GET`'s args).
+    ///   - startingIndex: Index to use for the first dynamic param encountered; allows continuous indexing
+    ///                    when combining a controller prefix with per-route params.
+    ///   - skipFirstUnlabeled: Skip the first non-`on:` argument (used for `@HTTP(.patch, ...)` where the
+    ///                         first argument is the HTTP method, not a path component).
+    static func parsePathComponents(
+        from arguments: LabeledExprListSyntax?,
+        startingIndex: Int = 0,
+        skipFirstUnlabeled: Bool = false
+    ) -> ParsedPathComponents {
+        var segments: [String] = []
+        var types: [String] = []
+        var currentIndex = startingIndex
+        var skippedFirstUnlabeled = false
+
+        guard let arguments else {
+            return ParsedPathComponents(routeRegistrationSegments: [], parameterTypes: [], nextIndex: startingIndex)
+        }
+
+        for argument in arguments {
+            if argument.label?.text == "on" {
+                continue
+            }
+            if skipFirstUnlabeled && !skippedFirstUnlabeled {
+                skippedFirstUnlabeled = true
+                continue
+            }
+
+            let exprStr = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+            if exprStr.hasSuffix(".self") {
+                let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
+                segments.append(":\(typeName.lowercased())\(currentIndex)")
+                types.append(typeName)
+                currentIndex += 1
+            } else {
+                let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+                segments.append(cleaned)
+            }
+        }
+
+        return ParsedPathComponents(routeRegistrationSegments: segments, parameterTypes: types, nextIndex: currentIndex)
+    }
+
+    /// If the macro is expanded inside a `@Controller`-annotated type declaration, return its attribute arguments.
+    /// Returns nil when not inside a controller or when the enclosing type is not `@Controller`-annotated.
+    static func enclosingControllerArguments(in context: some MacroExpansionContext) -> LabeledExprListSyntax? {
+        for lexical in context.lexicalContext {
+            let attributes: AttributeListSyntax? = {
+                if let structDecl = lexical.as(StructDeclSyntax.self) { return structDecl.attributes }
+                if let classDecl = lexical.as(ClassDeclSyntax.self) { return classDecl.attributes }
+                if let actorDecl = lexical.as(ActorDeclSyntax.self) { return actorDecl.attributes }
+                return nil
+            }()
+
+            guard let attributes else { continue }
+
+            for attribute in attributes {
+                guard case let .attribute(attr) = attribute,
+                      let identifier = attr.attributeName.as(IdentifierTypeSyntax.self),
+                      identifier.name.text == "Controller" else {
+                    continue
+                }
+                switch attr.arguments {
+                case .argumentList(let args):
+                    return args
+                default:
+                    // @Controller with no arguments.
+                    return LabeledExprListSyntax([])
+                }
+            }
+        }
+        return nil
+    }
+
     public static func expansion(
         of node: AttributeSyntax,
         providingPeersOf declaration: some DeclSyntaxProtocol,
@@ -77,34 +163,32 @@ enum HTTPMethodMacroUtilities {
             }
         }
 
-        // Parse path components and parameter types
-        var parameterTypes: [String] = []
+        // Detect enclosing @Controller so we can account for prefix-declared dynamic params.
+        // Prefix params come first in the handler's parameter list by convention.
+        let enclosingPrefix = enclosingControllerArguments(in: context).map {
+            parsePathComponents(from: $0, startingIndex: 0, skipFirstUnlabeled: false)
+        } ?? ParsedPathComponents(routeRegistrationSegments: [], parameterTypes: [], nextIndex: 0)
+
+        // Parse this macro's own path components, indexed continuously after the prefix's dynamic params.
+        let routeComponents = parsePathComponents(
+            from: arguments,
+            startingIndex: enclosingPrefix.nextIndex,
+            skipFirstUnlabeled: customHTTPMethod
+        )
+
+        let allParameterTypes = enclosingPrefix.parameterTypes + routeComponents.parameterTypes
+
+        // Detect `on:` label for standalone/freestanding usage (not used when inside a controller).
         var routeRegistrationVariable: String? = nil
-
-        var skippedHTTPMethod = false
         if let arguments {
-            for (_, argument) in arguments.enumerated() {
-                if argument.label?.text == "on" {
-                    routeRegistrationVariable = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-                    continue
-                }
-                // Skip the first non-on: argument for custom HTTP methods (that's the HTTP method itself)
-                if customHTTPMethod && !skippedHTTPMethod {
-                    skippedHTTPMethod = true
-                    continue
-                }
-
-                let exprStr = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                if exprStr.hasSuffix(".self") {
-                    let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                    parameterTypes.append(typeName)
-                }
+            for argument in arguments where argument.label?.text == "on" {
+                routeRegistrationVariable = argument.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                break
             }
         }
 
-        guard pathParams.count == parameterTypes.count else {
-            throw MacroError.invalidNumberOfParameters(macroName, parameterTypes.count, pathParams.count)
+        guard pathParams.count == allParameterTypes.count else {
+            throw MacroError.invalidNumberOfParameters(macroName, allParameterTypes.count, pathParams.count)
         }
 
         let functionName = funcDecl.name.text
@@ -113,6 +197,7 @@ enum HTTPMethodMacroUtilities {
         var parameterExtraction = ""
         var callParameters = "req: req"
         var pathParamIndex = 0
+        let dynamicIndexBase = 0  // index used in :typeN naming starts at 0 regardless of prefix vs route
 
         for (param, isAuth, isOptionalAuth) in allParamsWithAuth {
             let functionParameterName = param.firstName.text
@@ -131,10 +216,11 @@ enum HTTPMethodMacroUtilities {
                 }
                 callParameters += ", \(functionParameterName): \(varName)"
             } else {
-                let paramType = parameterTypes[pathParamIndex]
-                let parameterName = "\(paramType.lowercased())\(pathParamIndex)"
+                let paramType = allParameterTypes[pathParamIndex]
+                let globalIndex = dynamicIndexBase + pathParamIndex
+                let parameterName = "\(paramType.lowercased())\(globalIndex)"
                 parameterExtraction += """
-                let \(parameterName) = try req.parameters.require("\(paramType.lowercased())\(pathParamIndex)", as: \(paramType).self)
+                let \(parameterName) = try req.parameters.require("\(paramType.lowercased())\(globalIndex)", as: \(paramType).self)
 
                 """
                 callParameters += ", \(functionParameterName): \(parameterName)"
@@ -179,36 +265,7 @@ enum HTTPMethodMacroUtilities {
         }
 
         if let routeRegistrationVariable {
-            var currentDynamicPathParameterIndex = 0
-            var pathComponents: [String] = []
-            if let arguments {
-                var skippedHTTPMethodInPath = false
-                for (_, arg) in arguments.enumerated() {
-                    // Skip the `on:` argument
-                    if arg.label?.text == "on" {
-                        continue
-                    }
-                    // Skip the first non-on: argument for custom HTTP methods
-                    if customHTTPMethod && !skippedHTTPMethodInPath {
-                        skippedHTTPMethodInPath = true
-                        continue
-                    }
-                    let exprStr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                    // Check if it's a type (contains .self)
-                    if exprStr.hasSuffix(".self") {
-                        let typeName = exprStr.replacingOccurrences(of: ".self", with: "")
-                        pathComponents.append(":\(typeName.lowercased())\(currentDynamicPathParameterIndex)")
-                        currentDynamicPathParameterIndex += 1
-                    } else {
-                        // It's a string literal
-                        let cleaned = exprStr.trimmingCharacters(in: CharacterSet(charactersIn: "\""))
-                        pathComponents.append(cleaned)
-                    }
-                }
-            }
-
-            let path = pathComponents.joined(separator: "\", \"")
+            let path = routeComponents.routeRegistrationSegments.joined(separator: "\", \"")
             let pathRegistration = if path == "" {
                 ""
             } else {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacroUtilities.swift
@@ -292,6 +292,37 @@ enum HTTPMethodMacroUtilities {
         return [wrapperFunc]
     }
 
+    /// Parse all `@Middleware(...)` attributes on a function in source order, concatenating
+    /// their arguments. Stacking multiple `@Middleware` attributes is supported.
+    static func parseMiddleware(from funcDecl: FunctionDeclSyntax) -> [String] {
+        parseMiddlewareAttributes(from: funcDecl.attributes)
+    }
+
+    /// Parse all `@Middleware(...)` attributes on a type declaration (struct/class/actor), concatenating
+    /// their arguments. Stacking multiple `@Middleware` attributes is supported.
+    static func parseMiddleware(from declGroup: some DeclGroupSyntax) -> [String] {
+        parseMiddlewareAttributes(from: declGroup.attributes)
+    }
+
+    private static func parseMiddlewareAttributes(from attributes: AttributeListSyntax) -> [String] {
+        var result: [String] = []
+        for attribute in attributes {
+            guard case let .attribute(attr) = attribute,
+                  let identifier = attr.attributeName.as(IdentifierTypeSyntax.self),
+                  identifier.name.text == "Middleware",
+                  let args = attr.arguments?.as(LabeledExprListSyntax.self) else {
+                continue
+            }
+            for arg in args {
+                let exprStr = arg.expression.description.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !exprStr.isEmpty {
+                    result.append(exprStr)
+                }
+            }
+        }
+        return result
+    }
+
     /// Parse @AuthMiddleware attribute from a function declaration
     static func parseAuthMiddleware(from funcDecl: FunctionDeclSyntax) -> (type: String, middlewares: [String])? {
         for attribute in funcDecl.attributes {

--- a/Sources/VaporMacrosPlugin/Middleware/MiddlewareMacro.swift
+++ b/Sources/VaporMacrosPlugin/Middleware/MiddlewareMacro.swift
@@ -1,0 +1,15 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public struct MiddlewareMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        // This macro is purely declarative — ControllerMacro reads the attached
+        // @Middleware attributes (on the type or on member functions) and splices
+        // their expressions into `routes.grouped(...)` calls when generating boot.
+        []
+    }
+}

--- a/Sources/VaporMacrosPlugin/VaporMacros.swift
+++ b/Sources/VaporMacrosPlugin/VaporMacros.swift
@@ -18,5 +18,6 @@ struct VaporMacrosPlugin: CompilerPlugin {
         FreestandingPatchMacro.self,
         FreestandingHTTPMethodMacro.self,
         AuthMiddlewareMacro.self,
+        MiddlewareMacro.self,
     ]
 }

--- a/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/ControllerMacroIntegrationTests.swift
@@ -79,6 +79,77 @@ struct ControllerMacroIntegrationTests {
             }
         }
     }
+
+    // MARK: - Path Prefix (#3397)
+
+    @Test("Controller with string path prefix routes correctly")
+    func controllerStringPathPrefix() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedController())
+
+            try await app.testing().test(.get, "/api/prefixed/items") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "items")
+            }
+
+            try await app.testing().test(.post, "/api/prefixed/items") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "created")
+            }
+        }
+    }
+
+    @Test("Controller with dynamic path prefix extracts prefix param")
+    func controllerDynamicPathPrefix() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedTenantController())
+
+            try await app.testing().test(.get, "/tenants/42/posts") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "posts for tenant 42")
+            }
+        }
+    }
+
+    @Test("Controller with dynamic prefix + dynamic route param extracts both")
+    func controllerDynamicPrefixAndRouteParam() async throws {
+        try await withApp { app in
+            try await app.register(collection: PrefixedTenantController())
+
+            try await app.testing().test(.get, "/tenants/7/posts/welcome") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "post welcome for tenant 7")
+            }
+        }
+    }
+}
+
+// MARK: - Prefix test controllers
+
+@Controller("api", "prefixed")
+struct PrefixedController {
+    @GET("items")
+    func list(req: Request) async throws -> String {
+        return "items"
+    }
+
+    @POST("items")
+    func create(req: Request) async throws -> String {
+        return "created"
+    }
+}
+
+@Controller("tenants", Int.self)
+struct PrefixedTenantController {
+    @GET("posts")
+    func listPosts(req: Request, tenantID: Int) async throws -> String {
+        return "posts for tenant \(tenantID)"
+    }
+
+    @GET("posts", String.self)
+    func getPost(req: Request, tenantID: Int, slug: String) async throws -> String {
+        return "post \(slug) for tenant \(tenantID)"
+    }
 }
 
 // MARK: - Test Controller

--- a/Tests/VaporMacroIntegrationTests/MiddlewareIntegrationTests.swift
+++ b/Tests/VaporMacroIntegrationTests/MiddlewareIntegrationTests.swift
@@ -1,0 +1,156 @@
+#if MacroRouting
+import Testing
+import Vapor
+import VaporTesting
+import VaporMacros
+import HTTPTypes
+import RoutingKit
+import NIOConcurrencyHelpers
+
+@Suite("Middleware Macro Integration Tests")
+struct MiddlewareIntegrationTests {
+
+    @Test("Per-route @Middleware runs before the handler")
+    func perRouteMiddlewareRuns() async throws {
+        try await withApp { app in
+            try await app.register(collection: PerRouteMiddlewareController())
+
+            try await app.testing().test(.get, "/per-route") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "ok")
+                #expect(res.headers[.middlewareOrder] == "tag-A")
+            }
+        }
+    }
+
+    @Test("Type-level @Middleware runs for every route in the controller")
+    func typeLevelMiddlewareRuns() async throws {
+        try await withApp { app in
+            try await app.register(collection: TypeMiddlewareController())
+
+            try await app.testing().test(.get, "/type/first") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "first")
+                #expect(res.headers[.middlewareOrder] == "global")
+            }
+
+            try await app.testing().test(.get, "/type/second") { res in
+                #expect(res.status == .ok)
+                #expect(res.body.string == "second")
+                #expect(res.headers[.middlewareOrder] == "global")
+            }
+        }
+    }
+
+    @Test("Route-level @Middleware runs before @AuthMiddleware")
+    func routeMiddlewareRunsBeforeAuth() async throws {
+        try await withApp { app in
+            try await app.register(collection: AuthOrderController())
+
+            try await app.testing().test(
+                .get,
+                "/auth/order",
+                headers: [.authorization: "Bearer token"]
+            ) { res in
+                #expect(res.status == .ok)
+                // Middleware appends to the header in chain order. Route middleware is entered
+                // first (before auth), so "route" must precede "auth".
+                let chain = res.headers[.middlewareOrder] ?? ""
+                #expect(chain == "route,auth")
+            }
+        }
+    }
+
+    @Test("Type-level + per-route @Middleware compose with correct order")
+    func typeAndRouteMiddlewareCompose() async throws {
+        try await withApp { app in
+            try await app.register(collection: ComposedMiddlewareController())
+
+            try await app.testing().test(.get, "/composed/route") { res in
+                #expect(res.status == .ok)
+                let chain = res.headers[.middlewareOrder] ?? ""
+                // Type middleware is outermost (entered first), then per-route.
+                #expect(chain == "type,route")
+            }
+        }
+    }
+}
+
+// MARK: - Test middleware
+
+private extension HTTPField.Name {
+    static let middlewareOrder = HTTPField.Name("X-Middleware-Order")!
+}
+
+/// Prepends `tag` to the `X-Middleware-Order` response header so the final value reads
+/// middleware-entry order from left to right (outermost → innermost).
+struct TagMiddleware: Middleware {
+    let tag: String
+
+    func respond(to request: Request, chainingTo next: any Responder) async throws -> Response {
+        let response = try await next.respond(to: request)
+        let existing = response.headers[.middlewareOrder]
+        response.headers[.middlewareOrder] = existing.map { "\(tag),\($0)" } ?? tag
+        return response
+    }
+}
+
+struct MiddlewareTestUser: Authenticatable {
+    let name: String
+}
+
+struct MiddlewareTestAuthenticator: BearerAuthenticator {
+    typealias User = MiddlewareTestUser
+
+    func authenticate(bearer: BearerAuthorization, for request: Request) async throws {
+        if bearer.token == "token" {
+            request.auth.login(MiddlewareTestUser(name: "vapor"))
+        }
+    }
+}
+
+// MARK: - Test controllers
+
+@Controller("per-route")
+struct PerRouteMiddlewareController {
+    @GET()
+    @Middleware(TagMiddleware(tag: "tag-A"))
+    func route(req: Request) async throws -> String {
+        return "ok"
+    }
+}
+
+@Controller("type")
+@Middleware(TagMiddleware(tag: "global"))
+struct TypeMiddlewareController {
+    @GET("first")
+    func first(req: Request) async throws -> String {
+        return "first"
+    }
+
+    @GET("second")
+    func second(req: Request) async throws -> String {
+        return "second"
+    }
+}
+
+@Controller("auth")
+struct AuthOrderController {
+    @GET("order")
+    @Middleware(TagMiddleware(tag: "route"))
+    @AuthMiddleware(MiddlewareTestUser.self, MiddlewareTestAuthenticator(), TagMiddleware(tag: "auth"))
+    func order(req: Request, user: MiddlewareTestUser) async throws -> String {
+        return user.name
+    }
+}
+
+@Controller("composed")
+@Middleware(TagMiddleware(tag: "type"))
+struct ComposedMiddlewareController {
+    @GET("route")
+    @Middleware(TagMiddleware(tag: "route"))
+    func handler(req: Request) async throws -> String {
+        return "composed"
+    }
+}
+#endif

--- a/Tests/VaporMacroTests/ControllerMacroTests.swift
+++ b/Tests/VaporMacroTests/ControllerMacroTests.swift
@@ -289,19 +289,237 @@ struct ControllerMacroTests {
                 func getUsers(req: Request) async throws -> String {
                     return "Users"
                 }
-            
+
                 @Sendable func _route_getUsers(req: Request) async throws -> Response {
                     let result: some ResponseEncodable = try await getUsers(req: req)
                     return try await result.encodeResponse(for: req)
                 }
             }
-            
+
             extension UserController: RouteCollection {
                 func boot(routes: any RoutesBuilder) throws {
                 routes.get { req async throws -> Response in
                     try await self._route_getUsers(req: req)
                 }
-            
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    // MARK: - Path Prefix (#3397)
+
+    @Test("Test Controller with string path prefix")
+    func testControllerWithStringPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("api", "users")
+            struct UserController {
+                @GET()
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @POST("invite")
+                func invite(req: Request) async throws -> String {
+                    return "Invited"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+                func invite(req: Request) async throws -> String {
+                    return "Invited"
+                }
+
+                @Sendable func _route_invite(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await invite(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("api", "users")
+                group.get { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+                group.post("invite") { req async throws -> Response in
+                    try await self._route_invite(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with dynamic path prefix")
+    func testControllerWithDynamicPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("users", Int.self)
+            struct UserController {
+                @GET("posts")
+                func listPosts(req: Request, userID: Int) async throws -> String {
+                    return "posts for user \\(userID)"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func listPosts(req: Request, userID: Int) async throws -> String {
+                    return "posts for user \\(userID)"
+                }
+
+                @Sendable func _route_listPosts(req: Request) async throws -> Response {
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let result: some ResponseEncodable = try await listPosts(req: req, userID: int0)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("users", ":int0")
+                group.get("posts") { req async throws -> Response in
+                    try await self._route_listPosts(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with dynamic prefix and dynamic route param")
+    func testControllerWithDynamicPrefixAndRouteParam() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("users", Int.self)
+            struct UserController {
+                @GET("posts", String.self)
+                func getPost(req: Request, userID: Int, slug: String) async throws -> String {
+                    return "post \\(slug) for user \\(userID)"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func getPost(req: Request, userID: Int, slug: String) async throws -> String {
+                    return "post \\(slug) for user \\(userID)"
+                }
+
+                @Sendable func _route_getPost(req: Request) async throws -> Response {
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let string1 = try req.parameters.require("string1", as: String.self)
+                    let result: some ResponseEncodable = try await getPost(req: req, userID: int0, slug: string1)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("users", ":int0")
+                group.get("posts", ":string1") { req async throws -> Response in
+                    try await self._route_getPost(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller with empty path prefix is a no-op")
+    func testControllerEmptyPathPrefix() async throws {
+        assertMacroExpansion(
+            """
+            @Controller()
+            struct UserController {
+                @GET("api", "users")
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "Users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                routes.get("api", "users") { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Test Controller path prefix composes with AuthMiddleware")
+    func testControllerPathPrefixWithAuthMiddleware() async throws {
+        assertMacroExpansion(
+            """
+            @Controller("api", "users")
+            struct UserController {
+                @POST("promote", Int.self)
+                @AuthMiddleware(User.self, UserAuthMiddleware())
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+
+                @Sendable func _route_promote(req: Request) async throws -> Response {
+                    let user = try req.auth.require(User.self)
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let result: some ResponseEncodable = try await promote(req: req, user: user, id: int0)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let group = routes.grouped("api", "users")
+                group.grouped(UserAuthMiddleware()).post("promote", ":int0") { req async throws -> Response in
+                    try await self._route_promote(req: req)
+                }
+
                 }
             }
             """,

--- a/Tests/VaporMacroTests/Macros+SwiftTesting.swift
+++ b/Tests/VaporMacroTests/Macros+SwiftTesting.swift
@@ -29,6 +29,7 @@ let testMacros: [String: MacroSpec] = [
     "HTTP": MacroSpec(type: HTTPMethodMacro.self),
     "Controller": MacroSpec(type: ControllerMacro.self),
     "AuthMiddleware": MacroSpec(type: AuthMiddlewareMacro.self),
+    "Middleware": MacroSpec(type: MiddlewareMacro.self),
 ]
 
 #endif

--- a/Tests/VaporMacroTests/MiddlewareMacroTests.swift
+++ b/Tests/VaporMacroTests/MiddlewareMacroTests.swift
@@ -1,0 +1,266 @@
+#if MacroRouting
+import Testing
+import SwiftSyntaxMacrosGenericTestSupport
+
+#if canImport(VaporMacrosPlugin)
+
+@Suite("Middleware Macro Tests")
+struct MiddlewareMacroTests {
+    @Test("@Middleware is a no-op marker at expansion time")
+    func middlewareMacroIsMarker() {
+        assertMacroExpansion(
+            """
+            @Middleware(LoggingMiddleware())
+            func doWork(req: Request) async throws -> String {
+                return "ok"
+            }
+            """,
+            expandedSource: """
+            func doWork(req: Request) async throws -> String {
+                return "ok"
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Per-route @Middleware generates .grouped(...) in Controller boot")
+    func perRouteMiddlewareInController() {
+        assertMacroExpansion(
+            """
+            @Controller
+            struct UserController {
+                @GET("users")
+                @Middleware(LoggingMiddleware(), RateLimitMiddleware())
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                routes.grouped(LoggingMiddleware(), RateLimitMiddleware()).get("users") { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Type-level @Middleware wraps all routes outside the path group")
+    func typeLevelMiddleware() {
+        assertMacroExpansion(
+            """
+            @Controller("api", "users")
+            @Middleware(LoggingMiddleware(), AuthGuardMiddleware())
+            struct UserController {
+                @GET()
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @POST()
+                func create(req: Request) async throws -> String {
+                    return "created"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+                func create(req: Request) async throws -> String {
+                    return "created"
+                }
+
+                @Sendable func _route_create(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await create(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let base = routes.grouped(LoggingMiddleware(), AuthGuardMiddleware())
+                let group = base.grouped("api", "users")
+                group.get { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+                group.post { req async throws -> Response in
+                    try await self._route_create(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Route @Middleware runs before @AuthMiddleware")
+    func routeMiddlewareBeforeAuth() {
+        assertMacroExpansion(
+            """
+            @Controller
+            struct UserController {
+                @POST("promote", Int.self)
+                @Middleware(RateLimitMiddleware())
+                @AuthMiddleware(User.self, UserAuthMiddleware())
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func promote(req: Request, user: User, id: Int) async throws -> String {
+                    return "promoted"
+                }
+
+                @Sendable func _route_promote(req: Request) async throws -> Response {
+                    let user = try req.auth.require(User.self)
+                    let int0 = try req.parameters.require("int0", as: Int.self)
+                    let result: some ResponseEncodable = try await promote(req: req, user: user, id: int0)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                routes.grouped(RateLimitMiddleware()).grouped(UserAuthMiddleware()).post("promote", ":int0") { req async throws -> Response in
+                    try await self._route_promote(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Stacked @Middleware attributes concatenate in source order")
+    func stackedMiddleware() {
+        assertMacroExpansion(
+            """
+            @Controller
+            struct UserController {
+                @GET("users")
+                @Middleware(First())
+                @Middleware(Second(), Third())
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                routes.grouped(First(), Second(), Third()).get("users") { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+
+    @Test("Type-level and route-level @Middleware compose correctly")
+    func typeAndRouteMiddlewareCompose() {
+        assertMacroExpansion(
+            """
+            @Controller("api")
+            @Middleware(GlobalLogging())
+            struct UserController {
+                @GET("users")
+                @Middleware(RouteRateLimit())
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @GET("public")
+                func publicRoute(req: Request) async throws -> String {
+                    return "public"
+                }
+            }
+            """,
+            expandedSource: """
+            struct UserController {
+                func list(req: Request) async throws -> String {
+                    return "users"
+                }
+
+                @Sendable func _route_list(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await list(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+                func publicRoute(req: Request) async throws -> String {
+                    return "public"
+                }
+
+                @Sendable func _route_publicRoute(req: Request) async throws -> Response {
+                    let result: some ResponseEncodable = try await publicRoute(req: req)
+                    return try await result.encodeResponse(for: req)
+                }
+            }
+
+            extension UserController: RouteCollection {
+                func boot(routes: any RoutesBuilder) throws {
+                let base = routes.grouped(GlobalLogging())
+                let group = base.grouped("api")
+                group.grouped(RouteRateLimit()).get("users") { req async throws -> Response in
+                    try await self._route_list(req: req)
+                }
+                group.get("public") { req async throws -> Response in
+                    try await self._route_publicRoute(req: req)
+                }
+
+                }
+            }
+            """,
+            macroSpecs: testMacros,
+            failureHandler: FailureHandler.instance
+        )
+    }
+}
+
+#endif
+#endif


### PR DESCRIPTION
Resolves #3396.

> ⚠️ **Stacked on top of #3458** (`@Controller` path prefix). The diff against `vapor-5` includes #3458's changes until that one lands. To review only this PR's additions, compare against `macro-route-groups`: https://github.com/kylebrowning/vapor/compare/macro-route-groups...kylebrowning:vapor:macro-middleware

## Summary

`@Middleware` is a declarative marker macro that attaches middleware to either an entire `@Controller` type (applies to every route) or a single route function (applies only to that route). Arguments are spliced verbatim into `routes.grouped(...)` so any valid Swift expression works — including factory calls like `User.authenticator()`.

```swift
@Controller(\"api\", \"users\")
@Middleware(RequestLogger())             // applies to every route
struct UserController {
    @GET(\"search\")
    @Middleware(RateLimit(perSecond: 10)) // just this route
    func search(req: Request) async throws -> [User] { ... }

    @POST(\"promote\", Int.self)
    @Middleware(RateLimit(perSecond: 1))
    @AuthMiddleware(User.self, UserAuthMiddleware())
    func promote(req: Request, user: User, id: Int) async throws -> User { ... }
}
```

## Execution order

- **Type-level `@Middleware`** wraps `routes` *outside* the path group, so it runs before path matching (matches hand-written Vapor idiom: `routes.grouped(mw...).grouped(\"api\", \"users\")`).
- **Per-route `@Middleware`** runs *before* `@AuthMiddleware` so rate-limiters and logging observe unauthenticated requests too.
- **Stacked `@Middleware` attributes** on the same declaration concatenate their arguments in source order.

## Implementation

- New `MiddlewareMacro` peer macro, empty like `AuthMiddlewareMacro` — purely declarative.
- `HTTPMethodMacroUtilities.parseMiddleware(from:)` works on both function declarations and type decl groups.
- `ControllerMacro` reads type-level `@Middleware` → `let base = routes.grouped(typeMW...)`, then per-route `@Middleware` → `.grouped(routeMW...).grouped(authMW...)` before the HTTP method call.
- Integration tests prove execution order by having each test middleware prepend its tag to an `X-Middleware-Order` response header.
- `MiddlewareDemoController` and `MixedMiddlewareController` added to Development; `UserController` stays unchanged.

## Test plan

- [x] Unit tests: `@Middleware` as marker, per-route in controller, type-level wraps outside path group, route-before-auth ordering, stacked attributes, type + route composition.
- [x] Integration tests: per-route middleware runs, type-level middleware runs for every route, route-before-auth order verified via response header, type + route order verified.
- [x] All 49 unit tests + 23 integration tests pass (72 total, covering this PR and #3458).
- [x] `swift run Development` serves the new controllers end-to-end.