### PR TITLE
Include request URL in RouteNotFound error

### DIFF
--- a/Sources/Vapor/Responder/DefaultResponder.swift
+++ b/Sources/Vapor/Responder/DefaultResponder.swift
@@ -137,15 +137,29 @@ internal struct DefaultResponder: Responder {
 
 private struct NotFoundResponder: Responder {
     func respond(to request: Request) -> EventLoopFuture<Response> {
-        request.eventLoop.makeFailedFuture(RouteNotFound())
+        request.eventLoop.makeFailedFuture(RouteNotFound(requestURL: request.url.string))
     }
 }
 
-public struct RouteNotFound: Error {}
+public struct RouteNotFound: Error {
+    /// The URL of the request that could not be routed, when available.
+    public let requestURL: String?
+
+    public init(requestURL: String? = nil) {
+        self.requestURL = requestURL
+    }
+}
 
 extension RouteNotFound: AbortError {
     public var status: HTTPResponseStatus {
         .notFound
+    }
+
+    public var reason: String {
+        guard let url = self.requestURL else {
+            return "Not Found"
+        }
+        return "No route found for \"\(url)\""
     }
 }
 


### PR DESCRIPTION
Closes #3237.

Adds an optional `requestURL` to `RouteNotFound` and populates it from `NotFoundResponder` so that 404 logs and error bodies show which path missed the route table:

```
No route found for "/Icons/Services/SVG/someIcon.svg"
```

When `requestURL` is `nil`, the existing `"Not Found"` reason is used.

## Source compatibility

`RouteNotFound()` still compiles with no argument -- the new `init(requestURL: String? = nil)` defaults to `nil`, so callers outside the framework that construct the error directly keep working.

## Files

- `Sources/Vapor/Responder/DefaultResponder.swift`
  - `NotFoundResponder.respond(to:)` now passes `request.url.string`
  - `RouteNotFound` gains a stored `requestURL: String?` and the matching init
  - `AbortError.reason` returns the URL-aware message when present

Verified with `swift build --target Vapor` on Swift 6.3.