### PR TITLE
Update FileIO doc examples to async API

### DIFF
--- a/Sources/Vapor/Utilities/FileIO.swift
+++ b/Sources/Vapor/Utilities/FileIO.swift
@@ -24,18 +24,19 @@ extension Request {
 /// It can read files, both in their entirety and chunked.
 ///
 ///
-///     req.fileio.readFile(at: "/path/to/file.txt") { chunk in
-///         print(chunk) // part of file
+///     try await req.fileio.readFile(at: "/path/to/file.txt") { chunks in
+///         for try await chunk in chunks {
+///             print(chunk) // part of file
+///         }
 ///     }
 ///
-///     req.fileio.collectFile(at: "/path/to/file.txt").map { file in
-///         print(file) // entire file
-///     }
+///     let file = try await req.fileio.collectFile(at: "/path/to/file.txt")
+///     print(file) // entire file
 ///
 /// It can also create streaming HTTP responses.
 ///
-///     app.get("file-stream") { req -> Response in
-///         return req.fileio.streamFile(at: "/path/to/file.txt", for: req)
+///     app.get("file-stream") { req in
+///         try await req.fileio.streamFile(at: "/path/to/file.txt")
 ///     }
 ///
 /// Streaming file responses respect `E-Tag` headers present in the request.
@@ -91,7 +92,7 @@ public struct FileIO: Sendable {
 
     /// Reads the contents of a file at the supplied path.
     ///
-    ///     let data = try await req.fileio.collectFile(file: "/path/to/file.txt")
+    ///     let data = try await req.fileio.collectFile(at: "/path/to/file.txt")
     ///     print(data) // file data
     ///
     /// - parameters:
@@ -106,9 +107,11 @@ public struct FileIO: Sendable {
 
     /// Reads the contents of a file at the supplied path in chunks.
     ///
-    ///    for try await chunk in try await req.fileio.readFile(at: "/path/to/file.txt") {
-    ///        print("chunk: \(data)")
-    ///    }
+    ///     try await req.fileio.readFile(at: "/path/to/file.txt") { chunks in
+    ///         for try await chunk in chunks {
+    ///             print("chunk: \(chunk)")
+    ///         }
+    ///     }
     ///
     /// > Warning: It's the caller's responsibility to close the file handle provided in ``FileChunks`` when finished.
     ///
@@ -117,7 +120,7 @@ public struct FileIO: Sendable {
     ///     - chunkSize: Maximum size for the file data chunks.
     ///     - offset: The offset to start reading from.
     ///     - byteCount: The number of bytes to read from the file. If `nil`, the file will be read to the end.
-    /// - returns: `FileChunks` containing the file data chunks.
+    ///     - processChunks: Closure that receives the file data as a ``FileChunks`` async sequence.
     public func readFile(
         at path: String,
         chunkSize: Int64 = 128 * 1024, // was the default in NonBlockingFileIO
@@ -168,7 +171,7 @@ public struct FileIO: Sendable {
     /// automatically if an appropriate `MediaType` can be found for the file's suffix.
     ///
     ///     app.get("file-stream") { req in
-    ///         return req.fileio.streamFile(at: "/path/to/file.txt")
+    ///         try await req.fileio.streamFile(at: "/path/to/file.txt")
     ///     }
     ///
     /// - parameters:


### PR DESCRIPTION
fixes #2974

the doc-comment examples in `Sources/Vapor/Utilities/FileIO.swift` described the EventLoopFuture-based api removed in the vapor 5 migration. they did not compile against the real async signatures in the same file.

six examples updated:
- header `readFile` example used a closure-style call without `try await`
- header `collectFile` example used `.map` on a future
- header `streamFile` example had a `for:` argument no longer present
- `collectFile` method doc used arg label `file:` instead of `at:`
- `readFile` method doc iterated the return value, but the function takes a `processChunks` closure and returns `Void`
- `streamFile` method doc was missing `try await`

indentation in the chunked-read example was normalised to 5 spaces. doc-only change. `swift build --target Vapor` passes.