### PR TITLE
HTTPServer: add idle-connection timeout option

### DIFF
--- a/Sources/Vapor/HTTP/Server/CloseOnIdleHandler.swift
+++ b/Sources/Vapor/HTTP/Server/CloseOnIdleHandler.swift
@@ -1,0 +1,24 @@
+import Logging
+import NIOCore
+
+/// Closes the channel on receipt of an `IdleStateHandler.IdleStateEvent`.
+final class CloseOnIdleHandler: ChannelInboundHandler {
+    typealias InboundIn = NIOAny
+    typealias InboundOut = NIOAny
+
+    private let logger: Logger
+
+    init(logger: Logger) {
+        self.logger = logger
+    }
+
+    func userInboundEventTriggered(context: ChannelHandlerContext, event: Any) {
+        if event is IdleStateHandler.IdleStateEvent {
+            self.logger.debug("Closing idle connection")
+            // .all so an unresponsive peer doesn't strand the read side.
+            context.close(mode: .all, promise: nil)
+        } else {
+            context.fireUserInboundEventTriggered(event)
+        }
+    }
+}

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -586,20 +586,21 @@ private final class HTTPServerConnection: Sendable {
                     guard !configuration.supportVersions.contains(.two) else {
                         fatalError("Plaintext HTTP/2 (h2c) not yet supported.")
                     }
-                    return channel.eventLoop.makeCompletedFuture {
-                        if let idleTimeout = configuration.idleTimeout {
+                    if let idleTimeout = configuration.idleTimeout {
+                        do {
                             try channel.pipeline.syncOperations.addHandlers([
                                 IdleStateHandler(allTimeout: idleTimeout),
                                 CloseOnIdleHandler(logger: configuration.logger),
                             ])
+                        } catch {
+                            return channel.eventLoop.makeFailedFuture(error)
                         }
-                    }.flatMap { _ in
-                        channel.pipeline.addVaporHTTP1Handlers(
-                            application: application,
-                            responder: responder,
-                            configuration: configuration
-                        )
                     }
+                    return channel.pipeline.addVaporHTTP1Handlers(
+                        application: application,
+                        responder: responder,
+                        configuration: configuration
+                    )
                 }
             }
             

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -134,6 +134,9 @@ public final class HTTPServer: Server, Sendable {
         /// for additional information.
         public var connectionsPerServerTick: UInt
 
+        /// When set, inbound connections that have been idle for this duration will be closed. Default: `nil` (disabled).
+        public var idleTimeout: TimeAmount?
+
         public init(
             hostname: String = Self.defaultHostname,
             port: Int = Self.defaultPort,
@@ -150,7 +153,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -167,7 +171,8 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallback: customCertificateVerifyCallback,
-                connectionsPerServerTick: connectionsPerServerTick
+                connectionsPerServerTick: connectionsPerServerTick,
+                idleTimeout: idleTimeout
             )
         }
 
@@ -187,7 +192,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -204,7 +210,8 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallbackWithMetadata: customCertificateVerifyCallbackWithMetadata,
-                connectionsPerServerTick: connectionsPerServerTick
+                connectionsPerServerTick: connectionsPerServerTick,
+                idleTimeout: idleTimeout
             )
         }
 
@@ -223,7 +230,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.address = address
             self.backlog = backlog
@@ -245,6 +253,7 @@ public final class HTTPServer: Server, Sendable {
             self.customCertificateVerifyCallback = customCertificateVerifyCallback
             self.customCertificateVerifyCallbackWithMetadata = nil
             self.connectionsPerServerTick = connectionsPerServerTick
+            self.idleTimeout = idleTimeout
         }
 
         public init(
@@ -262,7 +271,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.address = address
             self.backlog = backlog
@@ -284,6 +294,7 @@ public final class HTTPServer: Server, Sendable {
             self.customCertificateVerifyCallback = nil
             self.customCertificateVerifyCallbackWithMetadata = customCertificateVerifyCallbackWithMetadata
             self.connectionsPerServerTick = connectionsPerServerTick
+            self.idleTimeout = idleTimeout
         }
     }
 
@@ -545,6 +556,12 @@ private final class HTTPServerConnection: Sendable {
                     }
                     return channel.eventLoop.makeCompletedFuture {
                         try channel.pipeline.syncOperations.addHandlers(tlsHandler)
+                        if let idleTimeout = configuration.idleTimeout {
+                            try channel.pipeline.syncOperations.addHandlers([
+                                IdleStateHandler(allTimeout: idleTimeout),
+                                CloseOnIdleHandler(logger: configuration.logger),
+                            ])
+                        }
                     }.flatMap { _ in
                         channel.configureHTTP2SecureUpgrade(h2ChannelConfigurator: { channel in
                             channel.configureHTTP2Pipeline(
@@ -569,11 +586,20 @@ private final class HTTPServerConnection: Sendable {
                     guard !configuration.supportVersions.contains(.two) else {
                         fatalError("Plaintext HTTP/2 (h2c) not yet supported.")
                     }
-                    return channel.pipeline.addVaporHTTP1Handlers(
-                        application: application,
-                        responder: responder,
-                        configuration: configuration
-                    )
+                    return channel.eventLoop.makeCompletedFuture {
+                        if let idleTimeout = configuration.idleTimeout {
+                            try channel.pipeline.syncOperations.addHandlers([
+                                IdleStateHandler(allTimeout: idleTimeout),
+                                CloseOnIdleHandler(logger: configuration.logger),
+                            ])
+                        }
+                    }.flatMap { _ in
+                        channel.pipeline.addVaporHTTP1Handlers(
+                            application: application,
+                            responder: responder,
+                            configuration: configuration
+                        )
+                    }
                 }
             }
             

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -156,7 +156,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -173,7 +174,8 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallback: customCertificateVerifyCallback,
-                connectionsPerServerTick: connectionsPerServerTick
+                connectionsPerServerTick: connectionsPerServerTick,
+                idleTimeout: idleTimeout
             )
         }
 
@@ -193,7 +195,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -210,7 +213,8 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallbackWithMetadata: customCertificateVerifyCallbackWithMetadata,
-                connectionsPerServerTick: connectionsPerServerTick
+                connectionsPerServerTick: connectionsPerServerTick,
+                idleTimeout: idleTimeout
             )
         }
 
@@ -229,7 +233,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.address = address
             self.backlog = backlog
@@ -251,7 +256,7 @@ public final class HTTPServer: Server, Sendable {
             self.customCertificateVerifyCallback = customCertificateVerifyCallback
             self.customCertificateVerifyCallbackWithMetadata = nil
             self.connectionsPerServerTick = connectionsPerServerTick
-            self.idleTimeout = nil
+            self.idleTimeout = idleTimeout
         }
 
         public init(
@@ -269,7 +274,8 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount? = nil
         ) {
             self.address = address
             self.backlog = backlog
@@ -290,47 +296,6 @@ public final class HTTPServer: Server, Sendable {
             self.shutdownTimeout = shutdownTimeout
             self.customCertificateVerifyCallback = nil
             self.customCertificateVerifyCallbackWithMetadata = customCertificateVerifyCallbackWithMetadata
-            self.connectionsPerServerTick = connectionsPerServerTick
-            self.idleTimeout = nil
-        }
-
-        public init(
-            address: BindAddress,
-            backlog: Int = 256,
-            reuseAddress: Bool = true,
-            tcpNoDelay: Bool = true,
-            responseCompression: ResponseCompressionConfiguration = .disabled,
-            requestDecompression: RequestDecompressionConfiguration = .enabled,
-            supportPipelining: Bool = true,
-            supportVersions: Set<HTTPVersionMajor>? = nil,
-            tlsConfiguration: TLSConfiguration? = nil,
-            serverName: String? = nil,
-            reportMetrics: Bool = true,
-            logger: Logger? = nil,
-            shutdownTimeout: TimeAmount = .seconds(10),
-            customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256,
-            idleTimeout: TimeAmount?
-        ) {
-            self.address = address
-            self.backlog = backlog
-            self.reuseAddress = reuseAddress
-            self.tcpNoDelay = tcpNoDelay
-            self.responseCompression = responseCompression
-            self.requestDecompression = requestDecompression
-            self.supportPipelining = supportPipelining
-            if let supportVersions = supportVersions {
-                self.supportVersions = supportVersions
-            } else {
-                self.supportVersions = tlsConfiguration == nil ? [.one] : [.one, .two]
-            }
-            self.tlsConfiguration = tlsConfiguration
-            self.serverName = serverName
-            self.reportMetrics = reportMetrics
-            self.logger = logger ?? Logger(label: "codes.vapor.http-server")
-            self.shutdownTimeout = shutdownTimeout
-            self.customCertificateVerifyCallback = customCertificateVerifyCallback
-            self.customCertificateVerifyCallbackWithMetadata = nil
             self.connectionsPerServerTick = connectionsPerServerTick
             self.idleTimeout = idleTimeout
         }

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -135,6 +135,9 @@ public final class HTTPServer: Server, Sendable {
         public var connectionsPerServerTick: UInt
 
         /// When set, inbound connections that have been idle for this duration will be closed. Default: `nil` (disabled).
+        ///
+        /// Behind a connection-pooling load balancer or reverse proxy, set this longer than the upstream's
+        /// idle-pool timeout to avoid the upstream reusing a connection the server has already closed.
         public var idleTimeout: TimeAmount?
 
         public init(

--- a/Sources/Vapor/HTTP/Server/HTTPServer.swift
+++ b/Sources/Vapor/HTTP/Server/HTTPServer.swift
@@ -156,8 +156,7 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256,
-            idleTimeout: TimeAmount? = nil
+            connectionsPerServerTick: UInt = 256
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -174,8 +173,7 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallback: customCertificateVerifyCallback,
-                connectionsPerServerTick: connectionsPerServerTick,
-                idleTimeout: idleTimeout
+                connectionsPerServerTick: connectionsPerServerTick
             )
         }
 
@@ -195,8 +193,7 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256,
-            idleTimeout: TimeAmount? = nil
+            connectionsPerServerTick: UInt = 256
         ) {
             self.init(
                 address: .hostname(hostname, port: port),
@@ -213,8 +210,7 @@ public final class HTTPServer: Server, Sendable {
                 logger: logger,
                 shutdownTimeout: shutdownTimeout,
                 customCertificateVerifyCallbackWithMetadata: customCertificateVerifyCallbackWithMetadata,
-                connectionsPerServerTick: connectionsPerServerTick,
-                idleTimeout: idleTimeout
+                connectionsPerServerTick: connectionsPerServerTick
             )
         }
 
@@ -233,8 +229,7 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
-            connectionsPerServerTick: UInt = 256,
-            idleTimeout: TimeAmount? = nil
+            connectionsPerServerTick: UInt = 256
         ) {
             self.address = address
             self.backlog = backlog
@@ -256,7 +251,7 @@ public final class HTTPServer: Server, Sendable {
             self.customCertificateVerifyCallback = customCertificateVerifyCallback
             self.customCertificateVerifyCallbackWithMetadata = nil
             self.connectionsPerServerTick = connectionsPerServerTick
-            self.idleTimeout = idleTimeout
+            self.idleTimeout = nil
         }
 
         public init(
@@ -274,8 +269,7 @@ public final class HTTPServer: Server, Sendable {
             logger: Logger? = nil,
             shutdownTimeout: TimeAmount = .seconds(10),
             customCertificateVerifyCallbackWithMetadata: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResultWithMetadata>) -> Void)?,
-            connectionsPerServerTick: UInt = 256,
-            idleTimeout: TimeAmount? = nil
+            connectionsPerServerTick: UInt = 256
         ) {
             self.address = address
             self.backlog = backlog
@@ -296,6 +290,47 @@ public final class HTTPServer: Server, Sendable {
             self.shutdownTimeout = shutdownTimeout
             self.customCertificateVerifyCallback = nil
             self.customCertificateVerifyCallbackWithMetadata = customCertificateVerifyCallbackWithMetadata
+            self.connectionsPerServerTick = connectionsPerServerTick
+            self.idleTimeout = nil
+        }
+
+        public init(
+            address: BindAddress,
+            backlog: Int = 256,
+            reuseAddress: Bool = true,
+            tcpNoDelay: Bool = true,
+            responseCompression: ResponseCompressionConfiguration = .disabled,
+            requestDecompression: RequestDecompressionConfiguration = .enabled,
+            supportPipelining: Bool = true,
+            supportVersions: Set<HTTPVersionMajor>? = nil,
+            tlsConfiguration: TLSConfiguration? = nil,
+            serverName: String? = nil,
+            reportMetrics: Bool = true,
+            logger: Logger? = nil,
+            shutdownTimeout: TimeAmount = .seconds(10),
+            customCertificateVerifyCallback: (@Sendable ([NIOSSLCertificate], EventLoopPromise<NIOSSLVerificationResult>) -> Void)? = nil,
+            connectionsPerServerTick: UInt = 256,
+            idleTimeout: TimeAmount?
+        ) {
+            self.address = address
+            self.backlog = backlog
+            self.reuseAddress = reuseAddress
+            self.tcpNoDelay = tcpNoDelay
+            self.responseCompression = responseCompression
+            self.requestDecompression = requestDecompression
+            self.supportPipelining = supportPipelining
+            if let supportVersions = supportVersions {
+                self.supportVersions = supportVersions
+            } else {
+                self.supportVersions = tlsConfiguration == nil ? [.one] : [.one, .two]
+            }
+            self.tlsConfiguration = tlsConfiguration
+            self.serverName = serverName
+            self.reportMetrics = reportMetrics
+            self.logger = logger ?? Logger(label: "codes.vapor.http-server")
+            self.shutdownTimeout = shutdownTimeout
+            self.customCertificateVerifyCallback = customCertificateVerifyCallback
+            self.customCertificateVerifyCallbackWithMetadata = nil
             self.connectionsPerServerTick = connectionsPerServerTick
             self.idleTimeout = idleTimeout
         }

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1108,6 +1108,56 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         wait(for: [closed], timeout: 3.0)
     }
 
+    func testIdleTimeoutResetsOnActivity() throws {
+        app.http.server.configuration.idleTimeout = .seconds(3)
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+
+        app.environment.arguments = ["serve"]
+        try app.start()
+
+        guard let localAddress = app.http.server.shared.localAddress else {
+            XCTFail("couldn't get local address")
+            return
+        }
+
+        let client = try ClientBootstrap(group: app.eventLoopGroup)
+            .connect(to: localAddress)
+            .wait()
+
+        // Three time-windowed observers of the same event (the channel closing).
+        let stableDuringInitialIdle = XCTestExpectation(description: "channel must not close during initial 2s idle")
+        stableDuringInitialIdle.isInverted = true
+        let stablePastOriginalDeadline = XCTestExpectation(description: "activity should have reset the timer past the original deadline")
+        stablePastOriginalDeadline.isInverted = true
+        let closedAfterResetWindow = XCTestExpectation(description: "server closes after the reset window elapses")
+
+        client.closeFuture.whenComplete { _ in
+            stableDuringInitialIdle.fulfill()
+            stablePastOriginalDeadline.fulfill()
+            closedAfterResetWindow.fulfill()
+        }
+
+        // Idle for 2s, still inside the original 3s window.
+        wait(for: [stableDuringInitialIdle], timeout: 2.0)
+
+        // Send a keep-alive request. Server-side activity in both directions
+        // resets the IdleStateHandler.
+        try client.writeAndFlush(ByteBuffer(string:
+            "GET / HTTP/1.1\r\nHost: foo\r\nConnection: keep-alive\r\n\r\n"
+        )).wait()
+
+        // Wait 2s. The original deadline (≈ t=3s) elapses inside this window;
+        // surviving past it proves the activity reset the timer.
+        wait(for: [stablePastOriginalDeadline], timeout: 2.0)
+        XCTAssertTrue(client.isActive, "activity at t=2s should have reset the idle timer")
+
+        // Connection should be deemed idle and close out after some time.
+        // Intentionally waiting a bit more generously to avoid races and flakiness.
+        wait(for: [closedAfterResetWindow], timeout: 1.5)
+        XCTAssertFalse(client.isActive, "server should have closed the connection after the reset window elapsed")
+    }
+
     func testRequestBodyStreamGetsFinalisedEvenIfClientDisappears() {
         app.http.server.configuration.hostname = "127.0.0.1"
         app.http.server.configuration.port = 0

--- a/Tests/VaporTests/ServerTests.swift
+++ b/Tests/VaporTests/ServerTests.swift
@@ -1083,7 +1083,31 @@ final class ServerTests: XCTestCase, @unchecked Sendable {
         let a = try app.http.client.shared.execute(request: request).wait()
         XCTAssertEqual(a.headers.connection, .keepAlive)
     }
-    
+
+    func testIdleTimeoutClosesIdleConnections() throws {
+        // With a 1s idle timeout, an inbound connection that sends nothing
+        // should be closed by the server within roughly 1s.
+        app.http.server.configuration.idleTimeout = .seconds(1)
+        app.http.server.configuration.hostname = "127.0.0.1"
+        app.http.server.configuration.port = 0
+
+        app.environment.arguments = ["serve"]
+        try app.start() 
+
+        guard let localAddress = app.http.server.shared.localAddress else {
+            XCTFail("couldn't get local address")
+            return
+        }
+
+        let client = try ClientBootstrap(group: app.eventLoopGroup)
+            .connect(to: localAddress)
+            .wait()
+
+        let closed = XCTestExpectation(description: "server closed the idle connection")
+        client.closeFuture.whenComplete { _ in closed.fulfill() }
+        wait(for: [closed], timeout: 3.0)
+    }
+
     func testRequestBodyStreamGetsFinalisedEvenIfClientDisappears() {
         app.http.server.configuration.hostname = "127.0.0.1"
         app.http.server.configuration.port = 0


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->
Adds a knob to specify an `idleTimeout`. if a connection has no activity (read AND write) for this amount of time, we close out the connection.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
