### PR TITLE
Add validation for multiple properties

### DIFF
--- a/Sources/Vapor/Validation/Validation.swift
+++ b/Sources/Vapor/Validation/Validation.swift
@@ -30,6 +30,31 @@ public struct Validation: Sendable {
             }
         }
     }
+
+    init<T>(
+        key: BasicCodingKey,
+        validating type: T.Type,
+        validator: Validator<T>,
+        customFailureDescription: String?
+    ) {
+        self.init(
+            key: key,
+            valuelessKeyBehavior: .ignore,
+            customFailureDescription: customFailureDescription
+        ) { decoder -> any ValidatorResult in
+            do {
+                return try validator.validate(type.init(from: decoder))
+            } catch DecodingError.valueNotFound {
+                return ValidatorResults.NotFound()
+            } catch DecodingError.typeMismatch(let type, _) {
+                return ValidatorResults.TypeMismatch(type: type)
+            } catch DecodingError.dataCorrupted(let context) {
+                return ValidatorResults.Invalid(reason: context.debugDescription)
+            } catch {
+                return ValidatorResults.Codable(error: error)
+            }
+        }
+    }
     
     init(nested key: BasicCodingKey, required: Bool, keyed validations: Validations, customFailureDescription: String?) {
         self.init(

--- a/Sources/Vapor/Validation/Validations.swift
+++ b/Sources/Vapor/Validation/Validations.swift
@@ -19,6 +19,40 @@ public struct Validations: Sendable {
         self.storage.append(.init(key: key, required: required, validator: validator, customFailureDescription: customFailureDescription))
     }
 
+    /// Adds a validation that runs against the complete decoded content.
+    ///
+    /// Use this overload when a validation depends on more than one property. The supplied type is decoded from the
+    /// same content passed to ``validate(request:)``, ``validate(query:contentConfiguration:)``, or
+    /// ``validate(json:contentConfiguration:)`` before the validator runs. It can be the complete content type or a
+    /// decodable projection containing only the properties needed by the validation.
+    ///
+    ///     validations.add(
+    ///         "location",
+    ///         validating: Item.self,
+    ///         is: .custom("contains a location description or photo URL") { item in
+    ///             item.locationDescription != nil || item.locationPhotoURL != nil
+    ///         }
+    ///     )
+    ///
+    /// - Parameters:
+    ///   - key: A key used to identify this validation in results and error messages.
+    ///   - type: The type to decode and validate.
+    ///   - validator: The validator to run against the decoded content.
+    ///   - customFailureDescription: An optional description to use when the validation fails.
+    public mutating func add<T>(
+        _ key: BasicCodingKey,
+        validating type: T.Type,
+        is validator: Validator<T>,
+        customFailureDescription: String? = nil
+    ) {
+        self.storage.append(.init(
+            key: key,
+            validating: type,
+            validator: validator,
+            customFailureDescription: customFailureDescription
+        ))
+    }
+
     public mutating func add(
         _ key: BasicCodingKey,
         result: any ValidatorResult,

--- a/Tests/VaporTests/ValidationTests.swift
+++ b/Tests/VaporTests/ValidationTests.swift
@@ -637,6 +637,71 @@ struct ValidationTests {
         #expect(error?.description == "key custom description")
     }
 
+    @Test("Validation for multiple properties", .bug("https://github.com/vapor/vapor/issues/1819"))
+    func testGH1819() throws {
+        struct Item: Codable, Sendable, Validatable {
+            var locationDescription: String?
+            var locationPhotoURL: String?
+
+            static func validations(_ validations: inout Validations) {
+                validations.add(
+                    "location",
+                    validating: Self.self,
+                    is: .custom("contains a location description or photo URL") { item in
+                        item.locationDescription != nil || item.locationPhotoURL != nil
+                    },
+                    customFailureDescription: "Must provide either a photo or a description of the location"
+                )
+                validations.add(
+                    "locationDescription",
+                    as: String.self,
+                    is: .count(10...),
+                    required: false
+                )
+            }
+        }
+
+        let missingLocationError = #expect(throws: ValidationsError.self) {
+            try Item.validate(json: "{}")
+        }
+        #expect(missingLocationError?.failures.count == 1)
+        #expect(missingLocationError?.failures.first?.key == "location")
+        #expect(
+            missingLocationError?.description == "Must provide either a photo or a description of the location"
+        )
+
+        #expect(throws: ValidationsError.self) {
+            try Item.validate(json: #"{"locationDescription":null,"locationPhotoURL":null}"#)
+        }
+
+        #expect(throws: Never.self) {
+            try Item.validate(json: #"{"locationDescription":"At the town square"}"#)
+        }
+        #expect(throws: Never.self) {
+            try Item.validate(
+                json: #"{"locationDescription":null,"locationPhotoURL":"https://example.com/location.jpg"}"#
+            )
+        }
+        #expect(throws: Never.self) {
+            try Item.validate(
+                json: #"{"locationDescription":"At the town square","locationPhotoURL":"https://example.com/location.jpg"}"#
+            )
+        }
+
+        let propertyError = #expect(throws: ValidationsError.self) {
+            try Item.validate(json: #"{"locationDescription":"Short"}"#)
+        }
+        #expect(propertyError?.failures.count == 1)
+        #expect(propertyError?.failures.first?.key == "locationDescription")
+
+        #expect(throws: Never.self) {
+            try Item.validate(query: "https://example.com/items?locationDescription=At%20the%20town%20square")
+        }
+        #expect(throws: ValidationsError.self) {
+            try Item.validate(query: "https://example.com/items")
+        }
+    }
+
     @Test("Test Double Negation Is Avoided")
     func testDoubleNegationIsAvoided() throws {
         var validations = Validations()


### PR DESCRIPTION
Adds whole-content validation for rules that depend on multiple properties (fixes #1819).

`Validations` now accepts a logical result key, a decodable content or projection type, and an existing `Validator`. The validator runs against the root decoder, so applications can express relationships such as requiring either a location description or photo URL while keeping the current field-level API unchanged.

```swift
validations.add(
    "location",
    validating: Item.self,
    is: .custom("contains a location description or photo URL") { item in
        item.locationDescription != nil || item.locationPhotoURL != nil
    }
)
```

Regression coverage includes JSON and query decoding, missing and null values, either or both fields, custom failure descriptions, and coexistence with field-level validation.
