### PR TITLE
Add a task local for Vapor.Request, and a matching middleware

### DIFF
--- a/Sources/Vapor/Middleware/RequestTaskLocalMiddleware.swift
+++ b/Sources/Vapor/Middleware/RequestTaskLocalMiddleware.swift
@@ -1,0 +1,43 @@
+
+extension Request {
+    /// The request associated with this task.
+    ///
+    /// The recommended way to set this task-local value is by adding ``RequestTaskLocalMiddleware`` to your app's middleware stack.
+    @TaskLocal public static var current: Request?
+
+    /// The request associated with this task.
+    ///
+    /// The recommended way to set this task-local value is by adding ``RequestTaskLocalMiddleware`` to your app's middleware stack.
+    ///
+    /// - Throws: When no task-local request is found.
+    public static var requireCurrent: Request {
+        get throws {
+            guard let current else {
+                throw Abort(
+                    .internalServerError,
+                    reason: "Task local Vapor.Request not found, make sure you added RequestTaskLocalMiddleware."
+                )
+            }
+            return current
+        }
+    }
+}
+
+/// A middleware that injects the ``Request`` into the task-local value ``Request/current``.
+///
+/// Task-local propagation allows the current task hierarchy to inspect the request in downstream
+/// middlewares and the request handler.
+public struct RequestTaskLocalMiddleware: AsyncMiddleware {
+
+    /// Creates a new middleware.
+    public init() {}
+
+    public func respond(
+        to request: Request,
+        chainingTo next: any AsyncResponder
+    ) async throws -> Response {
+        try await Request.$current.withValue(request) {
+            try await next.respond(to: request)
+        }
+    }
+}

--- a/Tests/VaporTests/RequestTaskLocalMiddlewareTests.swift
+++ b/Tests/VaporTests/RequestTaskLocalMiddlewareTests.swift
@@ -1,0 +1,49 @@
+import XCTVapor
+import XCTest
+import Vapor
+import NIOCore
+import Tracing
+
+final class RequestTaskLocalMiddlewareTests: XCTestCase {
+    var app: Application!
+
+    override func setUp() async throws {
+        app = try await Application.make(.testing)
+    }
+
+    override func tearDown() async throws {
+        try await app.asyncShutdown()
+    }
+
+    func testPropagation() async throws {
+        app
+            .grouped(RequestTaskLocalMiddleware())
+            .get("withTaskLocal") { req async throws -> String in
+                XCTAssertNotNil(Request.current)
+                XCTAssertNoThrow(try Request.requireCurrent)
+                return "all good"
+            }
+        app
+            .get("withoutTaskLocal") { req async throws -> String in
+                XCTAssertNil(Request.current)
+                do {
+                    _ = try Request.requireCurrent
+                    XCTFail("Expected an error to be thrown")
+                } catch let error as Abort {
+                    XCTAssertEqual(error.status, .internalServerError)
+                    XCTAssertEqual(error.reason, "Task local Vapor.Request not found, make sure you added RequestTaskLocalMiddleware.")
+                }
+                return "not found"
+            }
+        try await app
+            .testable()
+            .test(.GET, "/withTaskLocal") { res async in
+                XCTAssertEqual(res.status, .ok)
+                XCTAssertEqual(res.body.string, "all good")
+            }
+            .test(.GET, "/withoutTaskLocal") { res async in
+                XCTAssertEqual(res.status, .ok)
+                XCTAssertEqual(res.body.string, "not found")
+            }
+    }
+}


### PR DESCRIPTION
## Summary

> Note: This is primarily driven by the need of swift-openapi-vapor, but technically other adopters could benefit from it, so I'm starting with a PR here. Let me know if you'd like me to move it to swift-openapi-vapor instead.

This PR adds a task local for Vapor.Request, and a middleware that injects the current request into that task local automatically.

In projects like Swift OpenAPI Vapor, adopters don't get passed Vapor.Request directly, yet they sometimes need to inspect it (for auth, logger, etc). Putting the request into the task local is the easiest way to address that need.

If we land this, it'll remove the need for adopters of Swift OpenAPI Vapor to manually implement a similar middleware in each of their projects, plus it'll make it easier to inspect e.g. auth information in structured contexts.

## Test Plan

Added unit tests.
