### PR TITLE
Fix EndpointCache retry after failed request

### DIFF
--- a/Sources/Vapor/HTTP/EndpointCache.swift
+++ b/Sources/Vapor/HTTP/EndpointCache.swift
@@ -66,10 +66,11 @@ public actor EndpointCache<T>: Sendable where T: Decodable & Sendable {
             try await self.download(using: client)
         }
         self.request = newRequest
-        let result = try await newRequest.value
-        // Once the request finishes, clear the current request and return the data.
-        self.request = nil
-        return result
+        // Clear the current request whether it succeeds or fails. Otherwise, a
+        // failed task remains cached and all subsequent callers observe the same
+        // error without retrying the download.
+        defer { self.request = nil }
+        return try await newRequest.value
     }
 
     private func download(using client: any Client) async throws -> T {

--- a/Tests/VaporTests/EndpointCacheTests.swift
+++ b/Tests/VaporTests/EndpointCacheTests.swift
@@ -4,6 +4,7 @@ import Testing
 import Vapor
 import NIOCore
 import RoutingKit
+import HTTPTypes
 
 @Suite("Endpoint Cache Tests")
 struct EndpointCacheTests {
@@ -120,6 +121,39 @@ struct EndpointCacheTests {
                 #expect(try await request1 == request2)
                 let current = await currentActor.current
                 #expect(current == 1)
+            }
+        }
+    }
+
+    @Test("Test cache retries after a failed request")
+    func testEndpointCacheRetriesAfterFailure() async throws {
+        try await withApp { app in
+            let currentActor = CurrentActor()
+            struct Test: Content, Equatable {
+                let number: Int
+            }
+
+            app.get("number") { req -> Response in
+                let current = await currentActor.getCurrent()
+                await currentActor.increment()
+                guard current > 0 else {
+                    return Response(status: .internalServerError)
+                }
+
+                let response = Response()
+                try response.content.encode(Test(number: current))
+                response.headers.cacheControl = .init(maxAge: 10)
+                return response
+            }
+
+            try await withRunningApp(app: app) { port in
+                let cache = EndpointCache<Test>(uri: "http://localhost:\(port)/number")
+                let first = try? await cache.get(using: app.client)
+                #expect(first == nil)
+
+                let second = try await cache.get(using: app.client)
+                #expect(second.number == 1)
+                #expect(await currentActor.current == 2)
             }
         }
     }


### PR DESCRIPTION
## Summary

- Clear the in-flight request in defer so failed downloads do not poison the cache.
- Add a regression test for retrying after an HTTP 500 response.

Fixes #3483

## Testing

- git diff --check
- swiftc -parse passed for the changed source and test files
- swift test --filter EndpointCacheTests was blocked by the repository test build because the existing VaporMacroTests target could not load the TestingMacros plugin in the current CommandLineTools environment