### PR TITLE
Use main for the CI foundation check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
     secrets: inherit
 
   foundation-linking:
-    uses: vapor/ci/.github/workflows/check-foundation-linking.yml@check-foundation
+    uses: vapor/ci/.github/workflows/check-foundation-linking.yml@main
     permissions:
       contents: read
     with:


### PR DESCRIPTION
The Foundation check is now on main so no need to reference the branch it was built on