### PR TITLE
Turn on InternalImportsByDefault for Non-Vapor Targets

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -238,6 +238,7 @@ let package = Package(
 )
 
 var swiftSettings: [SwiftSetting] { [
+    .strictMemorySafety(),
     .enableUpcomingFeature("ExistentialAny"),
 //    .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),

--- a/Package.swift
+++ b/Package.swift
@@ -147,7 +147,7 @@ let package = Package(
                 .product(name: "HTTPTypes", package: "swift-http-types"),
                 .product(name: "Algorithms", package: "swift-algorithms")
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
 
         .target(
@@ -157,7 +157,7 @@ let package = Package(
                 "Vapor",
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
 
         // Development
@@ -170,7 +170,7 @@ let package = Package(
                 .product(name: "SwiftASN1", package: "swift-asn1"),
             ],
             resources: [.copy("Resources")],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
 
         // Testing
@@ -185,7 +185,7 @@ let package = Package(
                 .product(name: "Instrumentation", package: "swift-distributed-tracing"),
                 .product(name: "InMemoryLogging", package: "swift-log"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
         .testTarget(
             name: "VaporTests",
@@ -213,7 +213,7 @@ let package = Package(
                 .copy("Utilities/localhost.key"),
                 .copy("Utilities/long-test-file.txt"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
         .testTarget(
             name: "VaporMacroTests",
@@ -222,7 +222,7 @@ let package = Package(
                 .product(name: "SwiftSyntaxMacrosGenericTestSupport", package: "swift-syntax", condition: .when(traits: ["MacroRouting"])),
                 .product(name: "SwiftSyntaxMacroExpansion", package: "swift-syntax", condition: .when(traits: ["MacroRouting"])),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
         .testTarget(
             name: "VaporMacroIntegrationTests",
@@ -232,14 +232,14 @@ let package = Package(
                 .target(name: "VaporTesting"),
                 .product(name: "HTTPTypes", package: "swift-http-types"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.enableUpcomingFeature("InternalImportsByDefault")]
         ),
     ]
 )
 
 var swiftSettings: [SwiftSetting] { [
     .enableUpcomingFeature("ExistentialAny"),
-    //.enableUpcomingFeature("InternalImportsByDefault"),
+//    .enableUpcomingFeature("InternalImportsByDefault"),
     .enableUpcomingFeature("MemberImportVisibility"),
     .enableUpcomingFeature("InferIsolatedConformances"),
     .enableUpcomingFeature("NonisolatedNonsendingByDefault"),

--- a/Sources/Development/configure.swift
+++ b/Sources/Development/configure.swift
@@ -4,7 +4,7 @@ import X509
 import Logging
 import SwiftASN1
 
-public func configure(_ app: Application) async throws {
+func configure(_ app: Application) async throws {
     app.serverConfiguration.address = .hostname("127.0.0.1", port: 0)
     if app.environment == .tls {
         app.serverConfiguration.port = 8443

--- a/Sources/Development/routes.swift
+++ b/Sources/Development/routes.swift
@@ -13,7 +13,7 @@ struct Creds: Content {
     var password: String
 }
 
-public func routes(_ app: Application) async throws {
+func routes(_ app: Application) async throws {
     app.on(.get, "ping") { req -> StaticString in
         return "123" as StaticString
     }

--- a/Sources/VaporMacros/MacroInterface.swift
+++ b/Sources/VaporMacros/MacroInterface.swift
@@ -1,6 +1,6 @@
 #if MacroRouting
-import HTTPTypes
-import Vapor
+public import HTTPTypes
+public import Vapor
 
 @attached(extension, conformances: RouteCollection, names: named(boot(routes:)))
 public macro Controller() = #externalMacro(

--- a/Sources/VaporMacrosPlugin/AuthMiddleware/AuthMiddlewareMacro.swift
+++ b/Sources/VaporMacrosPlugin/AuthMiddleware/AuthMiddlewareMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 
 public struct AuthMiddlewareMacro: PeerMacro {
     public static func expansion(

--- a/Sources/VaporMacrosPlugin/ControllerMacro.swift
+++ b/Sources/VaporMacrosPlugin/ControllerMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/VaporMacrosPlugin/HTTPMethods/FreestandingRouteMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/FreestandingRouteMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import SwiftSyntaxBuilder
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPDeleteMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPDeleteMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import HTTPTypes
 
 public struct HTTPDeleteMacro: PeerMacro {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPGetMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPGetMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import HTTPTypes
 
 public struct HTTPGetMacro: PeerMacro {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPMethodMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntaxMacros
-import SwiftSyntax
+public import SwiftSyntaxMacros
+public import SwiftSyntax
 import HTTPTypes
 
 public struct HTTPMethodMacro: PeerMacro {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPatchMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPatchMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import HTTPTypes
 
 public struct HTTPPatchMacro: PeerMacro {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPostMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPostMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntaxMacros
-import SwiftSyntax
+public import SwiftSyntaxMacros
+public import SwiftSyntax
 import HTTPTypes
 
 public struct HTTPPostMacro: PeerMacro {

--- a/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPutMacro.swift
+++ b/Sources/VaporMacrosPlugin/HTTPMethods/HTTPPutMacro.swift
@@ -1,5 +1,5 @@
-import SwiftSyntax
-import SwiftSyntaxMacros
+public import SwiftSyntax
+public import SwiftSyntaxMacros
 import HTTPTypes
 
 public struct HTTPPutMacro: PeerMacro {

--- a/Sources/VaporTesting/+TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/+TestingHTTPResponse.swift
@@ -3,8 +3,8 @@ import FoundationEssentials
 #else
 import Foundation
 #endif
-import Testing
-import Vapor
+public import Testing
+public import Vapor
 
 public func expectContent<D>(
     _ type: D.Type,

--- a/Sources/VaporTesting/TaskLocalMetricsSystem.swift
+++ b/Sources/VaporTesting/TaskLocalMetricsSystem.swift
@@ -1,12 +1,12 @@
-import Metrics
+public import Metrics
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
 import NIOConcurrencyHelpers
-import MetricsTestKit
-import Testing
+public import MetricsTestKit
+public import Testing
 
 public final class TaskLocalMetricsSystemWrapper: MetricsFactory {
     public init() {}

--- a/Sources/VaporTesting/TaskLocalTracingSystem.swift
+++ b/Sources/VaporTesting/TaskLocalTracingSystem.swift
@@ -1,12 +1,6 @@
-import Tracing
-import InMemoryTracing
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
-import Foundation
-#endif
-import NIOConcurrencyHelpers
-import Testing
+public import Tracing
+public import InMemoryTracing
+public import Testing
 
 public final class TaskLocalTracingSystemWrapper: Tracer {
     public init() {}

--- a/Sources/VaporTesting/TestingApplication.swift
+++ b/Sources/VaporTesting/TestingApplication.swift
@@ -1,5 +1,5 @@
 import AsyncHTTPClient
-import Vapor
+public import Vapor
 import NIOPosix
 import NIOCore
 import NIOHTTPTypesHTTP1

--- a/Sources/VaporTesting/TestingApplicationNew.swift
+++ b/Sources/VaporTesting/TestingApplicationNew.swift
@@ -1,7 +1,8 @@
-import Vapor
-import HTTPTypes
-import NIOCore
-import Testing
+public import Vapor
+public import HTTPTypes
+#warning("This should be internal")
+public import NIOCore
+public import Testing
 
 extension Application {
     public func test(method: Method = .inMemory, testBlock: (any VaporTestingRunner) async throws -> Void) async throws {

--- a/Sources/VaporTesting/TestingApplicationTester.swift
+++ b/Sources/VaporTesting/TestingApplicationTester.swift
@@ -1,7 +1,8 @@
-import NIOCore
-import Testing
-import Vapor
-import HTTPTypes
+#warning("This should be internal")
+public import NIOCore
+public import Testing
+public import Vapor
+public import HTTPTypes
 
 public protocol TestingApplicationTester: Sendable {
     func performTest(request: TestingHTTPRequest) async throws -> TestingHTTPResponse

--- a/Sources/VaporTesting/TestingHTTPRequest.swift
+++ b/Sources/VaporTesting/TestingHTTPRequest.swift
@@ -1,7 +1,8 @@
-import NIOCore
+#warning("This should be internal")
+public import NIOCore
 import NIOConcurrencyHelpers
-import Vapor
-import HTTPTypes
+public import Vapor
+public import HTTPTypes
 
 public struct TestingHTTPRequest: Sendable {
     public var method: HTTPRequest.Method

--- a/Sources/VaporTesting/TestingHTTPResponse.swift
+++ b/Sources/VaporTesting/TestingHTTPResponse.swift
@@ -1,6 +1,7 @@
-import NIOCore
-import Vapor
-import HTTPTypes
+#warning("This should be internal")
+public import NIOCore
+public import Vapor
+public import HTTPTypes
 
 public struct TestingHTTPResponse: Sendable {
     public var status: HTTPResponse.Status

--- a/Sources/VaporTesting/Utilities.swift
+++ b/Sources/VaporTesting/Utilities.swift
@@ -1,4 +1,5 @@
-import NIOCore
+#warning("We should remove this when we don't need ByteBuffer")
+public import NIOCore
 
 extension ByteBuffer {
     public var string: String {

--- a/Sources/VaporTesting/withApp.swift
+++ b/Sources/VaporTesting/withApp.swift
@@ -1,11 +1,11 @@
-import Configuration
-import Vapor
+public import Configuration
+public import Vapor
 import NIOCore
 import NIOConcurrencyHelpers
 import ServiceLifecycle
 @testable import CoreMetrics
 @testable import Instrumentation
-import Logging
+public import Logging
 
 /// Perform a test while handling lifecycle of the application.
 /// Feel free to create a custom function like this, tailored to your project.


### PR DESCRIPTION
Turn on InternalImportsByDefault for everything but the main Vapor target as that's a bigger piece of work to be done separately
